### PR TITLE
feat: increase content width slider max to 3840px for 4K displays

### DIFF
--- a/src/lib/components/ReaderControls.svelte
+++ b/src/lib/components/ReaderControls.svelte
@@ -64,8 +64,8 @@
       <input
         type="range"
         min="560"
-        max="1200"
-        step="40"
+        max="3840"
+        step="80"
         value={$settings.maxWidth}
         oninput={(e) => settings.update((s) => ({ ...s, maxWidth: parseInt(e.currentTarget.value) }))}
         class="rc-range"


### PR DESCRIPTION
## Summary

- Increased the `max` value of the Content Width slider from `1200px` to `3840px` to support 4K and ultrawide monitors
- Increased `step` from `40px` to `80px` for smoother interaction across the wider range
- Default remains `720px` — **no visual change for existing users on upgrade**

## Changes

**File:** `src/lib/components/ReaderControls.svelte`

| Property | Before | After |
|----------|--------|-------|
| `max` | 1200 | 3840 |
| `step` | 40 | 80 |

## Testing

- [x] `pnpm build` passes with no errors
- [x] Tested in Tauri dev (slider extends to 3840px, content expands)
- [x] Default width unchanged at 720px
- [x] No other files modified

Fixes #1