### PR TITLE
feat: close-on-Escape with new Settings dialog (#4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,9 @@ Port 1420 is used for dev. Kill stale processes with `lsof -ti:1420 | xargs kill
 
 ## What This Is
 
-A lightweight, native desktop Markdown viewer & editor (~11MB) built with Tauri v2 + SvelteKit. Opens `.md` files and renders them beautifully with syntax highlighting, math, and diagrams. Includes a toggleable in-app editor (`Cmd+E` to enter, `Cmd+S` to save), an LLM paste-to-render mode for AI-generated markdown, and an Open URL fetcher. Targets macOS and Windows.
+A lightweight, native desktop Markdown viewer & editor (~8MB binary) built with Tauri v2 + SvelteKit. Opens `.md` files and renders them beautifully with syntax highlighting, math, and diagrams. Includes a toggleable in-app editor (`Cmd+E` to enter, `Cmd+S` to save), an LLM paste-to-render mode for AI-generated markdown, and an Open URL fetcher. A "Close on Escape" setting (on by default, toggleable in Settings) makes it usable as a file-manager viewer (right-click → Open With → MDHero → ESC). Targets macOS (Apple Silicon) and Windows. Open source (MIT).
+
+**Multi-repo:** the desktop app source is in this repo (`mdhero`). The marketing/landing site is in a sibling repo `mdhero-site` (Astro on Vercel) and also hosts the `/api/version` update endpoint that the app queries.
 
 ## Architecture
 
@@ -28,9 +30,13 @@ Single-window app. Rust backend handles file I/O, write-back, and watching; Svel
 
 **Scroll sync** (`src/lib/utils/scroll-sync.ts`): Toggling between viewer/raw/editor preserves the source-line position. Viewer reads the topmost visible block's `data-source-line`. Raw and editor estimate the line via `scrollTop / lineHeight`. The destination scrolls to put the same source line at the top. Mode toggles route through `switchMode(target)` in `+page.svelte`.
 
-**State management**: Svelte stores in `src/lib/stores/`. `tabs.ts` (multi-tab + edit state), `document.ts` (active document), `theme.ts` (light/dark/system, class-based), `settings.ts` (font/line/width/family, persisted to localStorage), `pinned.ts` (pinned folders), `recents.ts` (recent files), `toc.ts` (TOC entries + active heading), `updater.ts` (in-app update check against GitHub Releases).
+**State management**: Svelte stores in `src/lib/stores/`. `tabs.ts` (multi-tab + edit state), `document.ts` (active document), `theme.ts` (light/dark/system, class-based), `settings.ts` (font/line/width/family/`closeOnEscape`, persisted to localStorage), `pinned.ts` (pinned folders), `recents.ts` (recent files), `toc.ts` (TOC entries + active heading), `updater.ts` (24h-throttled update check against `mdhero.app/api/version` with GitHub fallback, per-version dismissal).
 
 **Tauri bridge** (`src/lib/tauri/`): `files.ts` wraps IPC commands and coordinates opening/reloading/saving. `watcher.ts` listens for `file-changed` events with own-save suppression.
+
+**Update checker** (`src/lib/stores/updater.ts`): App checks `https://mdhero.app/api/version` once per 24h (with GitHub Releases API as fallback) and surfaces an `UpdateBanner` on the home tab or `UpdateToast` on document tabs. The 24h throttle is enforced via `lastUpdateCheck` in localStorage. Per-version dismissals (`dismissedFor:0.2.x`) ensure "Later" hides only that specific version — the next release re-surfaces. The "Check for Updates…" menu item bypasses the throttle. Skipped in dev builds (`import.meta.env.DEV`) unless explicitly forced. The endpoint also increments aggregate DAU counters in Upstash (no device IDs, no IPs in storage — only OS family and source version).
+
+**Close-on-Escape** (default on, toggle in Settings → Behavior): when `settings.closeOnEscape` is true, ESC in viewer mode closes the current tab; if it was the last file tab, the app fully quits via the Rust `quit_app` command (`AppHandle::exit(0)`). Required on macOS because closing the last window normally leaves the app in the dock. ESC is gated by `!isEditing && !isInputFocused()` AND every open modal flag (search/paste/open/settings/lightbox). Modal precedence is enforced both ways: each modal's ESC handler `stopPropagation()`s, AND the window-level gate short-circuits while any of those flags are true — without both, ESC outside a focused modal would close the tab while the modal stayed visible.
 
 ## Key Files
 
@@ -44,6 +50,10 @@ Single-window app. Rust backend handles file I/O, write-back, and watching; Svel
 - `src/lib/components/Toolbar.svelte` — All toolbar buttons; everything stays visible and disables (with tooltip) when not applicable
 - `src/lib/components/EmptyState.svelte` — Home tab UI: pinned folders, recent files, plans
 - `src/lib/components/OpenDialog.svelte` — Cmd+O dialog: browse, recent, plans, pinned folders, URL
+- `src/lib/components/ReaderControls.svelte` — Reading Preferences popover ("Aa" toolbar button): font, size, line height, content width
+- `src/lib/components/SettingsDialog.svelte` — Settings dialog (gear toolbar button, `Cmd+,`): Behavior section with "Close on Escape" toggle. Sectioned layout designed to take more sections as the app grows.
+- `src/lib/components/UpdateBanner.svelte` — Inline update banner shown on home tab
+- `src/lib/components/UpdateToast.svelte` — Floating update toast shown on document tabs
 - `src/lib/utils/scroll-sync.ts` — Cross-mode scroll anchoring on source line
 - `src/lib/utils/llm.ts` — LLM output detection and unescaping (`\n`, `\"`, JSON strings)
 - `src/lib/utils/url.ts` — URL → raw URL conversion (GitHub blob, gist, GitLab, Bitbucket)
@@ -54,7 +64,7 @@ Single-window app. Rust backend handles file I/O, write-back, and watching; Svel
 
 ### Backend
 - `src-tauri/src/lib.rs` — Tauri setup: plugins, commands, menu, state, `OpenedFiles` buffer for "Open With"
-- `src-tauri/src/commands.rs` — Rust IPC commands: `read_markdown_file`, `write_markdown_file`, `list_claude_plans`, `list_folder_md_files`
+- `src-tauri/src/commands.rs` — Rust IPC commands: `read_markdown_file`, `write_markdown_file`, `list_claude_plans`, `list_folder_md_files`, `quit_app` (used by close-on-ESC)
 - `src-tauri/src/watcher.rs` — Rust file watcher (notify crate, watches parent dir)
 - `src-tauri/src/menu.rs` — Native menu bar
 - `src-tauri/tauri.conf.json` — Window config, file associations, CLI args, bundle settings
@@ -77,6 +87,10 @@ Single-window app. Rust backend handles file I/O, write-back, and watching; Svel
 - **Editor source-line sync limitation**: Source lines that visually wrap to multiple textarea rows are counted as one line. For typical markdown the drift is small. Long-prose paragraphs may be slightly off when entering/leaving the editor.
 - **Editor uses `position: fixed`**: Sits at `top: 75px; bottom: 0; z-index: 1`. This guarantees a single scrollbar (the textarea's). Don't change this casually — without it, double scrollbars appear and source-line sync breaks (because user might scroll the window instead of the textarea).
 - **Textarea binding**: Use `bind:value={localValue}` (two-way) on the editor textarea, not `value={x}` (one-way). One-way binding can desync the visible text from the property.
+- **Update-check throttle**: `updater.ts` enforces a 24h gap via `lastUpdateCheck` in localStorage. The "Check for Updates…" menu and the test endpoint can pass `force=true` to bypass. The check is also skipped in dev (`import.meta.env.DEV`) unless forced. Bumping the throttle window or removing the dev guard will pollute aggregate DAU counters tracked by the `/api/version` endpoint.
+- **DAU endpoint hygiene**: When curling `/api/version` for testing, always pass `?from=test&os=test` so the call lands in clearly-fake Upstash buckets instead of polluting real-version DAU stats. Real-looking values (e.g. `from=0.2.3&os=darwin`) silently masquerade as legitimate user traffic.
+- **`quit_app` on macOS specifically**: The close-on-ESC feature must call the Rust `quit_app` command (`AppHandle::exit(0)`) — `getCurrentWindow().close()` won't actually quit; macOS keeps the app in the dock. Windows/Linux quit on window close, but the explicit exit keeps behavior consistent.
+- **`mdhero.app/api/version` is the source of truth for "latest"**, defined in the sibling `mdhero-site` repo at `src/data/versions.ts`. After tagging a new release, bump that file and redeploy the site — otherwise the in-the-wild update banner stays on the old version. The response is cached at the Vercel edge for 5 minutes (`s-maxage=300`).
 
 ## Code Conventions
 
@@ -87,3 +101,15 @@ Single-window app. Rust backend handles file I/O, write-back, and watching; Svel
 - Tauri commands: defined in Rust with `#[tauri::command]`, called from frontend via `invoke()`.
 - Non-blocking Tauri calls: `setTitle`, `start_watching`, and other non-critical IPC calls use `.catch(() => {})` to prevent failures from breaking the main flow.
 - File structure: components in `src/lib/components/`, stores in `src/lib/stores/`, Tauri wrappers in `src/lib/tauri/`, rendering in `src/lib/renderer/`, helpers in `src/lib/utils/`.
+
+## Issue tracking workflow
+
+External GitHub Issues and Discussions that need design work get a private working notes doc in `docs/issues/` (gitignored). Naming: `issue-N-slug.md` and `discussion-N-slug.md`. Each doc captures: link to the issue, reporter, locked design decisions table, UX layouts, acceptance criteria, files to change, edge cases, out-of-scope items, and ship plan. Skip the doc for trivial bug fixes; create one when design needs more than a quick comment can carry.
+
+## Release & distribution
+
+- **Tag-driven CI**: pushing a `v*` tag triggers `.github/workflows/build.yml` → builds macOS (Apple Silicon) DMG + Windows EXE/MSI → publishes a GitHub Release.
+- **macOS signing**: ad-hoc signed only (`bundle.macOS.signingIdentity: "-"` in `tauri.conf.json`). No Apple Developer ID (yet). Users get a "cannot be verified" Gatekeeper dialog on first launch; workaround is `xattr -cr /Applications/MDHero.app` or System Settings → Privacy & Security → Open Anyway. Without the explicit `signingIdentity` config, the linker-only signature is malformed and produces the harsher "MDHero is damaged" dialog with no workaround — don't remove that line.
+- **Windows signing**: unsigned. Users get a SmartScreen warning workaround-able via "More info → Run anyway".
+- **No Intel Mac build** (CI matrix is `macos-latest` only = arm64). Adding `x86_64-apple-darwin` to the matrix is on the roadmap.
+- **Release flow** end-to-end: bump version in `package.json` + `tauri.conf.json` + `Cargo.toml` → commit → tag → push → CI builds → bump `mdhero-site/src/data/versions.ts` → commit + push site → write GitHub release notes via `gh release edit`.

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,6 +1,14 @@
 use std::fs;
 use std::path::Path;
 
+/// Explicitly quit the app — used by the "Close on Escape" setting when
+/// closing the last tab. On macOS this is needed because the standard
+/// "close window" behavior leaves the app running in the dock.
+#[tauri::command]
+pub fn quit_app(app: tauri::AppHandle) {
+    app.exit(0);
+}
+
 #[tauri::command]
 pub fn read_markdown_file(path: String) -> Result<String, String> {
     let p = Path::new(&path);

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -4,6 +4,13 @@ use std::path::Path;
 /// Explicitly quit the app — used by the "Close on Escape" setting when
 /// closing the last tab. On macOS this is needed because the standard
 /// "close window" behavior leaves the app running in the dock.
+///
+/// SAFETY: this bypasses any pending dirty-tab confirmation. Callers MUST
+/// close all dirty tabs via the frontend tab store (which surfaces a
+/// confirm() prompt) before invoking this. Currently only invoked from the
+/// close-on-ESC flow in `+page.svelte`, which guarantees this — either the
+/// last tab is closed via `handleCloseTab` first (dirty prompt included), or
+/// the invocation only happens from the home tab when no file tabs exist.
 #[tauri::command]
 pub fn quit_app(app: tauri::AppHandle) {
     app.exit(0);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -40,6 +40,7 @@ pub fn run() {
             commands::write_markdown_file,
             commands::list_claude_plans,
             commands::list_folder_md_files,
+            commands::quit_app,
             watcher::start_watching,
             watcher::stop_watching,
             get_opened_files,

--- a/src/lib/components/ImageLightbox.svelte
+++ b/src/lib/components/ImageLightbox.svelte
@@ -21,7 +21,11 @@
   }
 
   function handleKeydown(e: KeyboardEvent) {
-    if (e.key === "Escape") close();
+    if (e.key === "Escape") {
+      e.stopPropagation();
+      close();
+      return;
+    }
     if (e.key === "ArrowRight") next();
     if (e.key === "ArrowLeft") prev();
   }

--- a/src/lib/components/OpenDialog.svelte
+++ b/src/lib/components/OpenDialog.svelte
@@ -106,7 +106,10 @@
   }
 
   function handleKeydown(e: KeyboardEvent) {
-    if (e.key === "Escape") visible = false;
+    if (e.key === "Escape") {
+      e.stopPropagation();
+      visible = false;
+    }
   }
 
   function formatTime(ts: number): string {

--- a/src/lib/components/PasteModal.svelte
+++ b/src/lib/components/PasteModal.svelte
@@ -117,6 +117,7 @@
 
   function handleKeydown(e: KeyboardEvent) {
     if (e.key === "Escape") {
+      e.stopPropagation();
       visible = false;
     }
     if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {

--- a/src/lib/components/SearchOverlay.svelte
+++ b/src/lib/components/SearchOverlay.svelte
@@ -77,6 +77,7 @@
 
   function handleKeydown(e: KeyboardEvent) {
     if (e.key === "Escape") {
+      e.stopPropagation();
       close();
     } else if (e.key === "Enter") {
       if (e.shiftKey) {

--- a/src/lib/components/SettingsDialog.svelte
+++ b/src/lib/components/SettingsDialog.svelte
@@ -1,0 +1,235 @@
+<script lang="ts">
+  import { settings } from "$lib/stores/settings";
+
+  let { visible = $bindable(false) }: { visible: boolean } = $props();
+
+  function handleBackdropClick(e: MouseEvent) {
+    if (e.target === e.currentTarget) visible = false;
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === "Escape") {
+      e.stopPropagation();
+      visible = false;
+    }
+  }
+</script>
+
+{#if visible}
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div class="dialog-backdrop" onclick={handleBackdropClick} onkeydown={handleKeydown}>
+    <div class="dialog">
+      <div class="dialog-header">
+        <h2 class="dialog-title">Settings</h2>
+        <button onclick={() => (visible = false)} class="dialog-close" aria-label="Close">
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
+            <line x1="3" y1="3" x2="11" y2="11"/><line x1="11" y1="3" x2="3" y2="11"/>
+          </svg>
+        </button>
+      </div>
+
+      <div class="dialog-body">
+        <section class="settings-section">
+          <h3 class="section-title">Behavior</h3>
+
+          <label class="setting-row">
+            <div class="setting-text">
+              <span class="setting-label">Close on Escape</span>
+              <span class="setting-hint">Press ESC to close the current tab. App quits after the last tab.</span>
+            </div>
+            <input
+              type="checkbox"
+              checked={$settings.closeOnEscape}
+              onchange={(e) => settings.update((s) => ({ ...s, closeOnEscape: e.currentTarget.checked }))}
+              class="setting-switch"
+            />
+          </label>
+        </section>
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .dialog-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 50;
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    padding-top: 10vh;
+    background: rgba(0, 0, 0, 0.25);
+    backdrop-filter: blur(3px);
+    -webkit-backdrop-filter: blur(3px);
+  }
+
+  .dialog {
+    width: 480px;
+    max-height: 70vh;
+    background: white;
+    border: 1px solid #e5e5ea;
+    border-radius: 12px;
+    box-shadow: 0 20px 60px rgba(0,0,0,0.15), 0 4px 16px rgba(0,0,0,0.08);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  :global(html.dark) .dialog {
+    background: #2c2c2e;
+    border-color: #3a3a3c;
+    box-shadow: 0 20px 60px rgba(0,0,0,0.4);
+  }
+
+  .dialog-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 14px 16px;
+    border-bottom: 1px solid #f2f2f7;
+  }
+
+  :global(html.dark) .dialog-header {
+    border-bottom-color: #3a3a3c;
+  }
+
+  .dialog-title {
+    font-size: 15px;
+    font-weight: 600;
+    color: #1c1c1e;
+    margin: 0;
+  }
+
+  :global(html.dark) .dialog-title {
+    color: #e5e5e7;
+  }
+
+  .dialog-close {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    border: none;
+    background: none;
+    color: #aeaeb2;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: background 0.12s;
+  }
+
+  .dialog-close:hover {
+    background: #f2f2f7;
+    color: #636366;
+  }
+
+  :global(html.dark) .dialog-close:hover {
+    background: #3a3a3c;
+    color: #e5e5e7;
+  }
+
+  .dialog-body {
+    padding: 8px 16px 16px;
+    overflow-y: auto;
+  }
+
+  .settings-section {
+    padding-top: 12px;
+  }
+
+  .settings-section + .settings-section {
+    border-top: 1px solid #f2f2f7;
+    margin-top: 16px;
+  }
+
+  :global(html.dark) .settings-section + .settings-section {
+    border-top-color: #3a3a3c;
+  }
+
+  .section-title {
+    font-size: 11px;
+    font-weight: 600;
+    color: #aeaeb2;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin: 0 0 10px;
+  }
+
+  .setting-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 8px 0;
+    cursor: pointer;
+  }
+
+  .setting-text {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    flex: 1;
+    min-width: 0;
+  }
+
+  .setting-label {
+    font-size: 13px;
+    color: #1c1c1e;
+    font-weight: 500;
+  }
+
+  :global(html.dark) .setting-label {
+    color: #e5e5e7;
+  }
+
+  .setting-hint {
+    font-size: 11px;
+    color: #8e8e93;
+    line-height: 1.4;
+  }
+
+  :global(html.dark) .setting-hint {
+    color: #8e8e93;
+  }
+
+  .setting-switch {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 36px;
+    height: 20px;
+    background: #e5e5ea;
+    border-radius: 10px;
+    position: relative;
+    cursor: pointer;
+    transition: background 0.15s;
+    flex-shrink: 0;
+    margin: 0;
+  }
+
+  :global(html.dark) .setting-switch {
+    background: #3a3a3c;
+  }
+
+  .setting-switch::before {
+    content: "";
+    position: absolute;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    background: white;
+    top: 2px;
+    left: 2px;
+    transition: transform 0.15s;
+    box-shadow: 0 1px 2px rgba(0,0,0,0.15);
+  }
+
+  .setting-switch:checked,
+  :global(html.dark) .setting-switch:checked {
+    background: #0891B2;
+  }
+
+  .setting-switch:checked::before {
+    transform: translateX(16px);
+  }
+</style>

--- a/src/lib/components/Toolbar.svelte
+++ b/src/lib/components/Toolbar.svelte
@@ -17,6 +17,7 @@
     canEdit = false,
     onEditToggle = () => {},
     onSave = () => {},
+    onOpenSettings = () => {},
   }: {
     onPaste?: () => void;
     onOpen?: () => void;
@@ -28,6 +29,7 @@
     canEdit?: boolean;
     onEditToggle?: () => void;
     onSave?: () => void;
+    onOpenSettings?: () => void;
   } = $props();
 
   let currentHeading = $derived(
@@ -252,6 +254,18 @@
     </button>
 
     <div class="separator"></div>
+
+    <button
+      onclick={() => { closeAll(); onOpenSettings(); }}
+      class="btn btn-icon"
+      title="Settings (Cmd+,)"
+      aria-label="Settings"
+    >
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/>
+        <circle cx="12" cy="12" r="3"/>
+      </svg>
+    </button>
 
     <button onclick={handleThemeToggle} class="btn btn-icon" title="Toggle theme">
       {getThemeIcon($themeMode)}

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -5,6 +5,7 @@ export interface ReaderSettings {
   lineHeight: number;
   fontFamily: "sans" | "serif" | "mono";
   maxWidth: number;
+  closeOnEscape: boolean;
 }
 
 const STORAGE_KEY = "mdhero-settings";
@@ -15,6 +16,7 @@ function loadSettings(): ReaderSettings {
     lineHeight: 1.7,
     fontFamily: "sans",
     maxWidth: 720,
+    closeOnEscape: true,
   };
 
   if (typeof localStorage === "undefined") return defaults;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -8,6 +8,7 @@
   import { startFileWatcher } from "$lib/tauri/watcher";
   import { themeMode, cycleTheme } from "$lib/stores/theme";
   import { getCurrentWindow } from "@tauri-apps/api/window";
+  import { invoke } from "@tauri-apps/api/core";
   import { tocVisible, tocEntries } from "$lib/stores/toc";
   import Toolbar from "$lib/components/Toolbar.svelte";
   import MarkdownRenderer from "$lib/components/MarkdownRenderer.svelte";
@@ -18,6 +19,7 @@
   import SearchOverlay from "$lib/components/SearchOverlay.svelte";
   import PasteModal from "$lib/components/PasteModal.svelte";
   import OpenDialog from "$lib/components/OpenDialog.svelte";
+  import SettingsDialog from "$lib/components/SettingsDialog.svelte";
   import FrontmatterBar from "$lib/components/FrontmatterBar.svelte";
   import StatusBar from "$lib/components/StatusBar.svelte";
   import ProgressBar from "$lib/components/ProgressBar.svelte";
@@ -36,6 +38,7 @@
   let pasteVisible = $state(false);
   let pasteDefaultMode = $state<"paste" | "url">("paste");
   let openVisible = $state(false);
+  let settingsVisible = $state(false);
   let zenMode = $state(false);
   let rawMode = $state(false);
 
@@ -156,11 +159,12 @@
     switchMode(rawMode ? "viewer" : "raw");
   }
 
-  function handleCloseTab(id: string) {
+  function handleCloseTab(id: string): boolean {
     const t = $tabs.find((x) => x.id === id);
-    if (!t) return;
-    if (t.dirty && !confirm(`Discard unsaved changes to ${t.fileName}?`)) return;
+    if (!t) return false;
+    if (t.dirty && !confirm(`Discard unsaved changes to ${t.fileName}?`)) return false;
     tabStore.closeTab(id);
+    return true;
   }
 
   onMount(async () => {
@@ -329,6 +333,13 @@
       return;
     }
 
+    // Cmd+, open settings (macOS Preferences convention)
+    if ((e.metaKey || e.ctrlKey) && e.key === ",") {
+      e.preventDefault();
+      settingsVisible = !settingsVisible;
+      return;
+    }
+
     // Cmd+W close tab (with dirty confirm)
     if ((e.metaKey || e.ctrlKey) && e.key === "w") {
       e.preventDefault();
@@ -343,9 +354,35 @@
       return;
     }
 
-    // Escape — close panels
+    // Escape — close panels, then optionally close-tab-on-ESC
     if (e.key === "Escape") {
       if (zenMode) { zenMode = false; return; }
+
+      // Modals/overlays consume ESC first. Inner handlers stopPropagation when focus
+      // is inside them; this guard covers the focus-outside case (modal visible but
+      // user clicked elsewhere) so we don't nuke the tab while a modal is still up.
+      if (searchVisible || pasteVisible || openVisible || settingsVisible || lightboxVisible) return;
+
+      // Close-on-ESC: opt-in setting. Ignore in edit mode and when an input is focused
+      // (so users typing in search/paste/etc. don't accidentally trigger it).
+      if ($settings.closeOnEscape && !activeTab?.isEditing && !isInputFocused()) {
+        const tabsBeforeClose = $tabs.length;
+
+        if (activeTab && activeTab.id !== HOME_TAB_ID) {
+          // Close the current file tab (handleCloseTab manages the dirty prompt)
+          const closed = handleCloseTab(activeTab.id);
+          // If that was the last file tab, quit the app entirely.
+          // On macOS this is required — closing the window leaves the app in the dock.
+          if (closed && tabsBeforeClose === 1) {
+            invoke("quit_app").catch(() => {});
+          }
+        } else if (tabsBeforeClose === 0) {
+          // Active is home tab and no file tabs are open → quit
+          invoke("quit_app").catch(() => {});
+        }
+        // Else: home tab is active with file tabs in background — do nothing
+        // (don't nuke the user's session just because they happened to be on home)
+      }
       return;
     }
 
@@ -487,6 +524,7 @@
       canEdit={canEditActive}
       onEditToggle={handleEditToggle}
       onSave={() => activeTab && handleSave(activeTab)}
+      onOpenSettings={() => (settingsVisible = true)}
     />
     <TabBar onCloseTab={handleCloseTab} />
   {/if}
@@ -497,6 +535,7 @@
   <SearchOverlay bind:visible={searchVisible} />
   <PasteModal bind:visible={pasteVisible} defaultMode={pasteDefaultMode} />
   <OpenDialog bind:visible={openVisible} />
+  <SettingsDialog bind:visible={settingsVisible} />
 
   {#if !rendererReady}
     <div class="state-center">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -47,6 +47,15 @@
   let lightboxImages = $state<string[]>([]);
   let lightboxIndex = $state(0);
 
+  // Aggregated flag for any modal/overlay being visible. The close-on-ESC gate
+  // and any future "is the user mid-interaction?" check should read this so a
+  // new modal can't silently miss the gate by being added to state but not the
+  // ESC handler. Each modal's own ESC handler also calls stopPropagation(); the
+  // two together cover both focus-inside and focus-outside-modal cases.
+  let anyModalVisible = $derived(
+    searchVisible || pasteVisible || openVisible || settingsVisible || lightboxVisible
+  );
+
   const { tabs, activeTabId } = tabStore;
 
   let activeTab = $derived<Tab | null>($tabs.find((t) => t.id === $activeTabId) ?? null);
@@ -361,7 +370,8 @@
       // Modals/overlays consume ESC first. Inner handlers stopPropagation when focus
       // is inside them; this guard covers the focus-outside case (modal visible but
       // user clicked elsewhere) so we don't nuke the tab while a modal is still up.
-      if (searchVisible || pasteVisible || openVisible || settingsVisible || lightboxVisible) return;
+      // Add new modals to `anyModalVisible` (see top of script) to keep this safe.
+      if (anyModalVisible) return;
 
       // Close-on-ESC: opt-in setting. Ignore in edit mode and when an input is focused
       // (so users typing in search/paste/etc. don't accidentally trigger it).


### PR DESCRIPTION
## Summary
- ESC closes the current tab in viewer mode; if it was the last file tab, the app explicitly quits via a new Rust `quit_app` command (`AppHandle::exit(0)`) — required on macOS to clear the dock.
- New `SettingsDialog.svelte` (toolbar gear icon, `Cmd+,`) with a sectioned layout. Currently holds **Behavior → Close on Escape**. Reading-only preferences stay in the existing "Aa" popover.
- Modal precedence enforced two ways: each modal's ESC handler `stopPropagation()`s, AND the window-level close-on-ESC gate short-circuits while `anyModalVisible` is true. Either alone would leak (the latter handles ESC when focus is outside a visible modal).

## Deviations from the design doc
- **Default `true`, not `false`.** Reporter framed it as opt-in; shipping default-on after deciding ESC-to-close matches reader-app expectations and the cost of an unexpected ESC is low (file's still in Recents). Existing users keep their stored value (no migration). Worth calling out in release notes.
- **Setting lives in a new `SettingsDialog`, not `ReaderControls`.** The "Aa" Reader Preferences popover is gated behind having a file open, which would have prevented turning the setting on from a fresh launch on the home tab.
- **Three-button dirty prompt deferred.** Doc described `[Cancel] [Discard] [Save & Close]`; existing single `confirm("Discard unsaved changes…")` flow kept — covers the data-loss risk, the richer dialog is a separate UX improvement.

## Files changed
- `src-tauri/src/commands.rs`, `src-tauri/src/lib.rs` — `quit_app` Tauri command + `SAFETY` doc note
- `src/lib/components/SettingsDialog.svelte` (new) — sectioned modal, OpenDialog-style
- `src/lib/components/Toolbar.svelte` — gear icon button (Lucide cog), `onOpenSettings` prop
- `src/lib/stores/settings.ts` — `closeOnEscape: boolean` (default `true`)
- `src/routes/+page.svelte` — `Cmd+,` shortcut, `anyModalVisible` derived, ESC handler with close-on-ESC + modal gate, mount `<SettingsDialog>`
- `src/lib/components/SearchOverlay.svelte`, `PasteModal.svelte`, `OpenDialog.svelte`, `ImageLightbox.svelte` — `stopPropagation()` on ESC
- `CLAUDE.md` — Architecture + Key Files notes updated

## Test plan
- [ ] Setting off → ESC behavior unchanged (zen exits, modals close, nothing else)
- [ ] Setting on, single tab → ESC quits app (verify macOS Activity Monitor / dock — no MDHero left)
- [ ] Setting on, multiple tabs → ESC closes current tab, switches to next, app stays open; repeat until last → quits
- [ ] Setting on, edit mode → ESC does nothing
- [ ] Setting on, search overlay open → first ESC closes overlay, second ESC closes tab
- [ ] Same for paste / open / settings / image lightbox — two ESCs each
- [ ] Setting on, dirty tab → confirm dialog appears; Cancel keeps tab, OK closes (and quits if last)
- [ ] `Cmd+,` toggles Settings dialog from home tab AND with a file open
- [ ] Toggle reflects in dark mode (track turns teal when on)
- [ ] Windows: behavior parity with macOS

Refs #4