### PR TITLE
fix: remove literal backticks around inline code (#5)

### DIFF
--- a/src/lib/components/MarkdownRenderer.svelte
+++ b/src/lib/components/MarkdownRenderer.svelte
@@ -334,6 +334,13 @@
     color: #67E8F9;
   }
 
+  /* Strip the literal backticks @tailwindcss/typography adds around inline
+     code via ::before/::after — every other markdown renderer omits them. */
+  article :global(:not(pre) > code)::before,
+  article :global(:not(pre) > code)::after {
+    content: none;
+  }
+
   /* Tables */
   article :global(table) {
     border-collapse: collapse;


### PR DESCRIPTION
## Summary
- `@tailwindcss/typography` injects literal backtick characters around inline `<code>` via `::before`/`::after`. GitHub, GitLab, Bitbucket, etc. don't — this matches standard rendering behavior.
- 4-line CSS override in `src/lib/components/MarkdownRenderer.svelte` sets `content: none` on those pseudo-elements.
- Fenced code blocks (`pre > code`) are excluded via the `:not(pre) > code` selector, so they're unaffected.

Closes #5

## Test plan
- [x] Open `README.md` in MDHero → inline shortcuts like `Cmd+O`, `Cmd+E` render without backticks
- [x] Toggle dark mode → still no backticks
- [x] Fenced ` ```bash ` blocks in the README still render with syntax highlighting
- [x] Toggle viewer ↔ raw with `Ctrl+U` → raw view correctly shows the literal backticks in source