### PR TITLE
feat: save and restore reading progress per file

### DIFF
--- a/src/lib/stores/readingProgress.ts
+++ b/src/lib/stores/readingProgress.ts
@@ -1,0 +1,106 @@
+import { writable, get } from "svelte/store";
+
+const STORAGE_KEY = "mdhero:readingProgress";
+const MAX_ENTRIES = 500;
+
+interface ProgressEntry {
+  line: number;
+  lastAccessed: number;
+}
+
+interface ReadingProgressStore {
+  schemaVersion: 1;
+  entries: Record<string, ProgressEntry>;
+}
+
+function load(): ReadingProgressStore {
+  if (typeof localStorage === "undefined") return { schemaVersion: 1, entries: {} };
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { schemaVersion: 1, entries: {} };
+    const parsed = JSON.parse(raw);
+    if (parsed?.schemaVersion !== 1 || typeof parsed.entries !== "object") {
+      return { schemaVersion: 1, entries: {} };
+    }
+    return parsed as ReadingProgressStore;
+  } catch {
+    return { schemaVersion: 1, entries: {} };
+  }
+}
+
+function persist(store: ReadingProgressStore) {
+  if (typeof localStorage === "undefined") return;
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+}
+
+/**
+ * Normalize a tab's filePath into a storage key.
+ * - `paste://` tabs → null (skip entirely)
+ * - `url://` tabs → strip prefix, use the actual URL
+ * - Everything else → use as-is (absolute path from Tauri)
+ */
+function storageKey(filePath: string): string | null {
+  if (filePath.startsWith("paste://")) return null;
+  if (filePath.startsWith("url://")) return filePath.slice(6);
+  return filePath;
+}
+
+function evictIfNeeded(store: ReadingProgressStore) {
+  const keys = Object.keys(store.entries);
+  if (keys.length <= MAX_ENTRIES) return;
+
+  // Sort by lastAccessed ascending, remove oldest
+  const sorted = keys.sort(
+    (a, b) => store.entries[a].lastAccessed - store.entries[b].lastAccessed
+  );
+  const toRemove = sorted.slice(0, keys.length - MAX_ENTRIES);
+  for (const key of toRemove) {
+    delete store.entries[key];
+  }
+}
+
+const store = writable<ReadingProgressStore>(load());
+
+export function saveProgress(filePath: string, line: number) {
+  const key = storageKey(filePath);
+  if (!key) return;
+
+  store.update((s) => {
+    // Top-of-file rule: don't save line <= 1, delete stale entry instead
+    if (line <= 1) {
+      if (s.entries[key]) {
+        delete s.entries[key];
+        persist(s);
+      }
+      return s;
+    }
+
+    s.entries[key] = { line, lastAccessed: Date.now() };
+    evictIfNeeded(s);
+    persist(s);
+    return s;
+  });
+}
+
+export function getProgress(filePath: string): number | undefined {
+  const key = storageKey(filePath);
+  if (!key) return undefined;
+  const entry = get(store).entries[key];
+  return entry?.line;
+}
+
+export function clearProgress(filePath: string) {
+  const key = storageKey(filePath);
+  if (!key) return;
+  store.update((s) => {
+    delete s.entries[key];
+    persist(s);
+    return s;
+  });
+}
+
+export function clearAllProgress() {
+  const empty: ReadingProgressStore = { schemaVersion: 1, entries: {} };
+  store.set(empty);
+  persist(empty);
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -31,6 +31,7 @@
   import { checkForUpdates, updateAvailable, updateDismissed, checkInFlight } from "$lib/stores/updater";
   import { get } from "svelte/store";
   import { getCurrentSourceLine, scrollToSourceLine, type ViewMode } from "$lib/utils/scroll-sync";
+  import { saveProgress, getProgress } from "$lib/stores/readingProgress";
 
   let rendererReady = $state(false);
   let lastWatchedPath: string | null = null;
@@ -55,6 +56,84 @@
   let anyModalVisible = $derived(
     searchVisible || pasteVisible || openVisible || settingsVisible || lightboxVisible
   );
+
+  // Reading progress: debounced scroll save + restore guard
+  let isRestoring = false;
+  let restoreTimer: ReturnType<typeof setTimeout> | undefined;
+  let scrollSaveTimer: ReturnType<typeof setTimeout> | undefined;
+
+  function handleScrollForProgress() {
+    if (isRestoring) return;
+    const tab = tabStore.getActiveTab();
+    if (!tab || tab.isEditing) return;
+    if (tab.filePath.startsWith("paste://")) return;
+
+    clearTimeout(scrollSaveTimer);
+    scrollSaveTimer = setTimeout(() => {
+      // Tiny-file edge case: skip save if document fits in viewport
+      if (document.documentElement.scrollHeight <= window.innerHeight) return;
+      const line = getCurrentSourceLine("viewer");
+      saveProgress(tab.filePath, line);
+    }, 500);
+  }
+
+  function saveProgressNow() {
+    clearTimeout(scrollSaveTimer);
+    const tab = tabStore.getActiveTab();
+    if (!tab || tab.isEditing) return;
+    if (tab.filePath.startsWith("paste://")) return;
+    // Tiny-file edge case: skip save if document fits in viewport
+    if (document.documentElement.scrollHeight <= window.innerHeight) return;
+    const line = getCurrentSourceLine("viewer");
+    saveProgress(tab.filePath, line);
+  }
+
+  function handleVisibilityChange() {
+    if (document.hidden) saveProgressNow();
+  }
+
+  function restoreProgress(filePath: string) {
+    const savedLine = getProgress(filePath);
+    if (!savedLine || savedLine <= 1) return;
+
+    isRestoring = true;
+    clearTimeout(restoreTimer);
+
+    tick().then(() => {
+      requestAnimationFrame(() => {
+        const article = document.querySelector("article.prose");
+        if (!article) { isRestoring = false; return; }
+
+        const elements = Array.from(article.querySelectorAll<HTMLElement>("[data-source-line]"));
+        if (elements.length === 0) { isRestoring = false; return; }
+
+        // Find the saved line if it still exists, else fall back to the last
+        // element (handles file-shrunk case where saved line no longer exists)
+        let target: HTMLElement | null = null;
+        for (const el of elements) {
+          const elLine = parseInt(el.getAttribute("data-source-line") || "0", 10);
+          if (elLine >= savedLine) { target = el; break; }
+        }
+        if (!target) target = elements[elements.length - 1];
+
+        // Tiny-file edge case: don't restore if document fits in viewport
+        const docHeight = document.documentElement.scrollHeight;
+        if (docHeight <= window.innerHeight) { isRestoring = false; return; }
+
+        target.scrollIntoView({ behavior: "smooth", block: "start" });
+
+        // Clear isRestoring on scrollend (preferred) with 1s timeout fallback
+        // for WebViews that don't support the scrollend event
+        const clearRestoring = () => {
+          clearTimeout(restoreTimer);
+          window.removeEventListener("scrollend", clearRestoring);
+          isRestoring = false;
+        };
+        window.addEventListener("scrollend", clearRestoring, { once: true });
+        restoreTimer = setTimeout(clearRestoring, 1000);
+      });
+    });
+  }
 
   const { tabs, activeTabId } = tabStore;
 
@@ -172,6 +251,11 @@
     const t = $tabs.find((x) => x.id === id);
     if (!t) return false;
     if (t.dirty && !confirm(`Discard unsaved changes to ${t.fileName}?`)) return false;
+    // Flush reading progress before closing — catches the case where user
+    // scrolls and closes within the 500ms debounce window
+    if (t.id === $activeTabId) {
+      saveProgressNow();
+    }
     tabStore.closeTab(id);
     return true;
   }
@@ -212,8 +296,11 @@
       }
     };
 
-    // Listen for keyboard shortcuts
+    // Listen for keyboard shortcuts and scroll for reading progress
     window.addEventListener("keydown", handleKeydown);
+    window.addEventListener("scroll", handleScrollForProgress, { passive: true });
+    window.addEventListener("beforeunload", saveProgressNow);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
 
     // Check for files opened via "Open With" / double-click (buffered in Rust state)
     try {
@@ -240,6 +327,9 @@
 
     return () => {
       window.removeEventListener("keydown", handleKeydown);
+      window.removeEventListener("scroll", handleScrollForProgress);
+      window.removeEventListener("beforeunload", saveProgressNow);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
   });
 
@@ -466,6 +556,23 @@
 
     // Skip if same tab
     if (id === prevTabId) return;
+
+    // Save reading progress for the tab we're leaving.
+    // At this point in the $effect, $activeTabId has changed but the DOM still
+    // shows the previous tab's content (docStore.set happens below), so
+    // getCurrentSourceLine reads the correct article elements. We flush the
+    // debounce to ensure nothing is lost on rapid tab switches.
+    if (prevTabId && prevTabId !== HOME_TAB_ID) {
+      const prevTab = allTabs.find((t) => t.id === prevTabId);
+      if (prevTab && !prevTab.isEditing && !prevTab.filePath.startsWith("paste://")) {
+        clearTimeout(scrollSaveTimer);
+        if (document.documentElement.scrollHeight > window.innerHeight) {
+          const line = getCurrentSourceLine("viewer");
+          saveProgress(prevTab.filePath, line);
+        }
+      }
+    }
+
     prevTabId = id;
 
     if (!id || id === HOME_TAB_ID) {
@@ -506,6 +613,11 @@
     tick().then(() => {
       requestAnimationFrame(() => {
         window.scrollTo(0, savedScroll);
+        // Restore reading progress (smooth-scroll to saved source line)
+        // Only if the tab is at scroll 0 (freshly opened or re-opened)
+        if (savedScroll === 0) {
+          restoreProgress(tab.filePath);
+        }
       });
     });
   });


### PR DESCRIPTION
## Summary

- Adds a new `readingProgress` store (`src/lib/stores/readingProgress.ts`) with `save/get/clear/clearAll` API, LRU eviction at 500 entries, schema-versioned localStorage persistence, and safe JSON parse
- Wires debounced scroll save (500ms), restore on tab activation, and flush on `beforeunload` + `visibilitychange` in `+page.svelte`
- Uses `data-source-line` anchoring so saved positions survive font/width/reflow changes between sessions
- Handles edge cases: file-shrunk (closest valid line), tiny-file (skip if fits viewport), top-of-file cleanup, `paste://` skip, `url://` key normalization, `isRestoring` guard with `scrollend` + 1s timeout fallback

Closes #7

## Test plan

- [ ] Open a long markdown file, scroll halfway, close and reopen — should smooth-scroll to saved position
- [ ] Open a short file that fits in viewport — no progress should be saved
- [ ] Scroll back to top of a file, reopen — should open at top (no scroll animation)
- [ ] Switch between tabs rapidly — positions should be preserved per tab
- [ ] Open same content via file path and URL — tracked as separate entries
- [ ] Paste markdown via `paste://` — no progress tracking
- [ ] Edit mode should not trigger save or restore
- [ ] Truncate a file between sessions — should restore to closest valid line