### PR TITLE
fix: prevent scroll from leaking through settings dialog to backgroun…

### DIFF
--- a/src/lib/components/SettingsDialog.svelte
+++ b/src/lib/components/SettingsDialog.svelte
@@ -138,6 +138,7 @@
   .dialog-body {
     padding: 8px 16px 16px;
     overflow-y: auto;
+    overscroll-behavior: contain;
   }
 
   .settings-section {


### PR DESCRIPTION
…d document

## Summary

<!-- What does this PR do? Keep it brief. -->

#**# Changes**

`Update(src\lib\components\SettingsDialog.svelte)`
 
## Testing

<!-- How did you verify this works? -->

- [ ] Tested in dev mode (`pnpm tauri dev`)
- [ ] Works in both light and dark mode
- [ ] No regressions in existing features
- [ ] `pnpm check` passes
