### PR TITLE
feat: cross-platform About dialog + reading progress

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -58,6 +58,7 @@ pub fn run() {
                         "theme" => { let _ = window.eval("window.__mdhero_toggle_theme?.()"); }
                         "find" => { let _ = window.eval("window.__mdhero_find?.()"); }
                         "check_updates" => { let _ = window.eval("window.__mdhero_check_updates?.()"); }
+                        "about" => { let _ = window.eval("window.__mdhero_about?.()"); }
                         _ => {}
                     }
                 }

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -10,7 +10,7 @@ pub fn create_menu(app: &AppHandle) -> Result<Menu<tauri::Wry>, tauri::Error> {
         "MDHero",
         true,
         &[
-            &PredefinedMenuItem::about(app, Some("About MDHero"), None)?,
+            &MenuItem::with_id(app, "about", "About MDHero", true, None::<&str>)?,
             &MenuItem::with_id(app, "check_updates", "Check for Updates…", true, None::<&str>)?,
             &PredefinedMenuItem::separator(app)?,
             &PredefinedMenuItem::hide(app, None)?,

--- a/src/lib/components/AboutDialog.svelte
+++ b/src/lib/components/AboutDialog.svelte
@@ -1,0 +1,201 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { getVersion } from "@tauri-apps/api/app";
+
+  let { visible = $bindable(false) }: { visible: boolean } = $props();
+  let appVersion = $state("");
+
+  onMount(async () => {
+    try {
+      appVersion = await getVersion();
+    } catch {
+      appVersion = "unknown";
+    }
+  });
+
+  function handleBackdropClick(e: MouseEvent) {
+    if (e.target === e.currentTarget) visible = false;
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === "Escape") {
+      e.stopPropagation();
+      visible = false;
+    }
+  }
+</script>
+
+{#if visible}
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div class="dialog-backdrop" onclick={handleBackdropClick} onkeydown={handleKeydown}>
+    <div class="dialog">
+      <div class="dialog-header">
+        <h2 class="dialog-title">About MDHero</h2>
+        <button onclick={() => (visible = false)} class="dialog-close" aria-label="Close">
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
+            <line x1="3" y1="3" x2="11" y2="11"/><line x1="11" y1="3" x2="3" y2="11"/>
+          </svg>
+        </button>
+      </div>
+
+      <div class="dialog-body">
+        <div class="about-content">
+          <div class="app-icon">
+            <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M4 4h16a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2z"/>
+              <path d="M7 10h2l1.5 2L12 10h2"/>
+              <line x1="7" y1="14" x2="17" y2="14"/>
+            </svg>
+          </div>
+          <h3 class="app-name">MDHero</h3>
+          <p class="app-version">Version {appVersion}</p>
+          <p class="app-description">A beautiful, fast Markdown viewer for your desktop.</p>
+          <a
+            class="app-link"
+            href="https://github.com/vaibhavuk-dev/mdhero"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            github.com/vaibhavuk-dev/mdhero
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .dialog-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 50;
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    padding-top: 10vh;
+    background: rgba(0, 0, 0, 0.25);
+    backdrop-filter: blur(3px);
+    -webkit-backdrop-filter: blur(3px);
+  }
+
+  .dialog {
+    width: 360px;
+    background: white;
+    border: 1px solid #e5e5ea;
+    border-radius: 12px;
+    box-shadow: 0 20px 60px rgba(0,0,0,0.15), 0 4px 16px rgba(0,0,0,0.08);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  :global(html.dark) .dialog {
+    background: #2c2c2e;
+    border-color: #3a3a3c;
+    box-shadow: 0 20px 60px rgba(0,0,0,0.4);
+  }
+
+  .dialog-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 14px 16px;
+    border-bottom: 1px solid #f2f2f7;
+  }
+
+  :global(html.dark) .dialog-header {
+    border-bottom-color: #3a3a3c;
+  }
+
+  .dialog-title {
+    font-size: 15px;
+    font-weight: 600;
+    color: #1c1c1e;
+    margin: 0;
+  }
+
+  :global(html.dark) .dialog-title {
+    color: #e5e5e7;
+  }
+
+  .dialog-close {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    border: none;
+    background: none;
+    color: #aeaeb2;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: background 0.12s;
+  }
+
+  .dialog-close:hover {
+    background: #f2f2f7;
+    color: #636366;
+  }
+
+  :global(html.dark) .dialog-close:hover {
+    background: #3a3a3c;
+    color: #e5e5e7;
+  }
+
+  .dialog-body {
+    padding: 24px 16px 28px;
+  }
+
+  .about-content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: 6px;
+  }
+
+  .app-icon {
+    color: #0891B2;
+    margin-bottom: 4px;
+  }
+
+  .app-name {
+    font-size: 18px;
+    font-weight: 700;
+    color: #1c1c1e;
+    margin: 0;
+  }
+
+  :global(html.dark) .app-name {
+    color: #e5e5e7;
+  }
+
+  .app-version {
+    font-size: 13px;
+    color: #8e8e93;
+    margin: 0;
+  }
+
+  .app-description {
+    font-size: 13px;
+    color: #636366;
+    margin: 8px 0 0;
+    line-height: 1.4;
+  }
+
+  :global(html.dark) .app-description {
+    color: #aeaeb2;
+  }
+
+  .app-link {
+    font-size: 12px;
+    color: #0891B2;
+    text-decoration: none;
+    margin-top: 8px;
+    transition: opacity 0.12s;
+  }
+
+  .app-link:hover {
+    opacity: 0.75;
+  }
+</style>

--- a/src/lib/stores/readingProgress.ts
+++ b/src/lib/stores/readingProgress.ts
@@ -1,0 +1,106 @@
+import { writable, get } from "svelte/store";
+
+const STORAGE_KEY = "mdhero:readingProgress";
+const MAX_ENTRIES = 500;
+
+interface ProgressEntry {
+  line: number;
+  lastAccessed: number;
+}
+
+interface ReadingProgressStore {
+  schemaVersion: 1;
+  entries: Record<string, ProgressEntry>;
+}
+
+function load(): ReadingProgressStore {
+  if (typeof localStorage === "undefined") return { schemaVersion: 1, entries: {} };
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { schemaVersion: 1, entries: {} };
+    const parsed = JSON.parse(raw);
+    if (parsed?.schemaVersion !== 1 || typeof parsed.entries !== "object") {
+      return { schemaVersion: 1, entries: {} };
+    }
+    return parsed as ReadingProgressStore;
+  } catch {
+    return { schemaVersion: 1, entries: {} };
+  }
+}
+
+function persist(store: ReadingProgressStore) {
+  if (typeof localStorage === "undefined") return;
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+}
+
+/**
+ * Normalize a tab's filePath into a storage key.
+ * - `paste://` tabs → null (skip entirely)
+ * - `url://` tabs → strip prefix, use the actual URL
+ * - Everything else → use as-is (absolute path from Tauri)
+ */
+function storageKey(filePath: string): string | null {
+  if (filePath.startsWith("paste://")) return null;
+  if (filePath.startsWith("url://")) return filePath.slice(6);
+  return filePath;
+}
+
+function evictIfNeeded(store: ReadingProgressStore) {
+  const keys = Object.keys(store.entries);
+  if (keys.length <= MAX_ENTRIES) return;
+
+  // Sort by lastAccessed ascending, remove oldest
+  const sorted = keys.sort(
+    (a, b) => store.entries[a].lastAccessed - store.entries[b].lastAccessed
+  );
+  const toRemove = sorted.slice(0, keys.length - MAX_ENTRIES);
+  for (const key of toRemove) {
+    delete store.entries[key];
+  }
+}
+
+const store = writable<ReadingProgressStore>(load());
+
+export function saveProgress(filePath: string, line: number) {
+  const key = storageKey(filePath);
+  if (!key) return;
+
+  store.update((s) => {
+    // Top-of-file rule: don't save line <= 1, delete stale entry instead
+    if (line <= 1) {
+      if (s.entries[key]) {
+        delete s.entries[key];
+        persist(s);
+      }
+      return s;
+    }
+
+    s.entries[key] = { line, lastAccessed: Date.now() };
+    evictIfNeeded(s);
+    persist(s);
+    return s;
+  });
+}
+
+export function getProgress(filePath: string): number | undefined {
+  const key = storageKey(filePath);
+  if (!key) return undefined;
+  const entry = get(store).entries[key];
+  return entry?.line;
+}
+
+export function clearProgress(filePath: string) {
+  const key = storageKey(filePath);
+  if (!key) return;
+  store.update((s) => {
+    delete s.entries[key];
+    persist(s);
+    return s;
+  });
+}
+
+export function clearAllProgress() {
+  const empty: ReadingProgressStore = { schemaVersion: 1, entries: {} };
+  store.set(empty);
+  persist(empty);
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -31,6 +31,7 @@
   import { checkForUpdates, updateAvailable, updateDismissed, checkInFlight } from "$lib/stores/updater";
   import { get } from "svelte/store";
   import { getCurrentSourceLine, scrollToSourceLine, type ViewMode } from "$lib/utils/scroll-sync";
+  import { saveProgress, getProgress } from "$lib/stores/readingProgress";
 
   let rendererReady = $state(false);
   let lastWatchedPath: string | null = null;
@@ -55,6 +56,84 @@
   let anyModalVisible = $derived(
     searchVisible || pasteVisible || openVisible || settingsVisible || lightboxVisible
   );
+
+  // Reading progress: debounced scroll save + restore guard
+  let isRestoring = false;
+  let restoreTimer: ReturnType<typeof setTimeout> | undefined;
+  let scrollSaveTimer: ReturnType<typeof setTimeout> | undefined;
+
+  function handleScrollForProgress() {
+    if (isRestoring) return;
+    const tab = tabStore.getActiveTab();
+    if (!tab || tab.isEditing) return;
+    if (tab.filePath.startsWith("paste://")) return;
+
+    clearTimeout(scrollSaveTimer);
+    scrollSaveTimer = setTimeout(() => {
+      // Tiny-file edge case: skip save if document fits in viewport
+      if (document.documentElement.scrollHeight <= window.innerHeight) return;
+      const line = getCurrentSourceLine("viewer");
+      saveProgress(tab.filePath, line);
+    }, 500);
+  }
+
+  function saveProgressNow() {
+    clearTimeout(scrollSaveTimer);
+    const tab = tabStore.getActiveTab();
+    if (!tab || tab.isEditing) return;
+    if (tab.filePath.startsWith("paste://")) return;
+    // Tiny-file edge case: skip save if document fits in viewport
+    if (document.documentElement.scrollHeight <= window.innerHeight) return;
+    const line = getCurrentSourceLine("viewer");
+    saveProgress(tab.filePath, line);
+  }
+
+  function handleVisibilityChange() {
+    if (document.hidden) saveProgressNow();
+  }
+
+  function restoreProgress(filePath: string) {
+    const savedLine = getProgress(filePath);
+    if (!savedLine || savedLine <= 1) return;
+
+    isRestoring = true;
+    clearTimeout(restoreTimer);
+
+    tick().then(() => {
+      requestAnimationFrame(() => {
+        const article = document.querySelector("article.prose");
+        if (!article) { isRestoring = false; return; }
+
+        const elements = Array.from(article.querySelectorAll<HTMLElement>("[data-source-line]"));
+        if (elements.length === 0) { isRestoring = false; return; }
+
+        // Find the saved line if it still exists, else fall back to the last
+        // element (handles file-shrunk case where saved line no longer exists)
+        let target: HTMLElement | null = null;
+        for (const el of elements) {
+          const elLine = parseInt(el.getAttribute("data-source-line") || "0", 10);
+          if (elLine >= savedLine) { target = el; break; }
+        }
+        if (!target) target = elements[elements.length - 1];
+
+        // Tiny-file edge case: don't restore if document fits in viewport
+        const docHeight = document.documentElement.scrollHeight;
+        if (docHeight <= window.innerHeight) { isRestoring = false; return; }
+
+        target.scrollIntoView({ behavior: "smooth", block: "start" });
+
+        // Clear isRestoring on scrollend (preferred) with 1s timeout fallback
+        // for WebViews that don't support the scrollend event
+        const clearRestoring = () => {
+          clearTimeout(restoreTimer);
+          window.removeEventListener("scrollend", clearRestoring);
+          isRestoring = false;
+        };
+        window.addEventListener("scrollend", clearRestoring, { once: true });
+        restoreTimer = setTimeout(clearRestoring, 1000);
+      });
+    });
+  }
 
   const { tabs, activeTabId } = tabStore;
 
@@ -172,6 +251,11 @@
     const t = $tabs.find((x) => x.id === id);
     if (!t) return false;
     if (t.dirty && !confirm(`Discard unsaved changes to ${t.fileName}?`)) return false;
+    // Flush reading progress before closing — catches the case where user
+    // scrolls and closes within the 500ms debounce window
+    if (t.id === $activeTabId) {
+      saveProgressNow();
+    }
     tabStore.closeTab(id);
     return true;
   }
@@ -212,8 +296,11 @@
       }
     };
 
-    // Listen for keyboard shortcuts
+    // Listen for keyboard shortcuts and scroll for reading progress
     window.addEventListener("keydown", handleKeydown);
+    window.addEventListener("scroll", handleScrollForProgress, { passive: true });
+    window.addEventListener("beforeunload", saveProgressNow);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
 
     // Check for files opened via "Open With" / double-click (buffered in Rust state)
     try {
@@ -240,6 +327,9 @@
 
     return () => {
       window.removeEventListener("keydown", handleKeydown);
+      window.removeEventListener("scroll", handleScrollForProgress);
+      window.removeEventListener("beforeunload", saveProgressNow);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
   });
 
@@ -466,6 +556,23 @@
 
     // Skip if same tab
     if (id === prevTabId) return;
+
+    // Save reading progress for the tab we're leaving.
+    // At this point in the $effect, $activeTabId has changed but the DOM still
+    // shows the previous tab's content (docStore.set happens below), so
+    // getCurrentSourceLine reads the correct article elements. We flush the
+    // debounce to ensure nothing is lost on rapid tab switches.
+    if (prevTabId && prevTabId !== HOME_TAB_ID) {
+      const prevTab = allTabs.find((t) => t.id === prevTabId);
+      if (prevTab && !prevTab.isEditing && !prevTab.filePath.startsWith("paste://")) {
+        clearTimeout(scrollSaveTimer);
+        if (document.documentElement.scrollHeight > window.innerHeight) {
+          const line = getCurrentSourceLine("viewer");
+          saveProgress(prevTab.filePath, line);
+        }
+      }
+    }
+
     prevTabId = id;
 
     if (!id || id === HOME_TAB_ID) {
@@ -506,6 +613,11 @@
     tick().then(() => {
       requestAnimationFrame(() => {
         window.scrollTo(0, savedScroll);
+        // Restore reading progress (smooth-scroll to saved source line)
+        // Only if the tab is at scroll 0 (freshly opened or re-opened)
+        if (savedScroll === 0) {
+          restoreProgress(tab.filePath);
+        }
       });
     });
   });

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -20,6 +20,7 @@
   import PasteModal from "$lib/components/PasteModal.svelte";
   import OpenDialog from "$lib/components/OpenDialog.svelte";
   import SettingsDialog from "$lib/components/SettingsDialog.svelte";
+  import AboutDialog from "$lib/components/AboutDialog.svelte";
   import FrontmatterBar from "$lib/components/FrontmatterBar.svelte";
   import StatusBar from "$lib/components/StatusBar.svelte";
   import ProgressBar from "$lib/components/ProgressBar.svelte";
@@ -40,6 +41,7 @@
   let pasteDefaultMode = $state<"paste" | "url">("paste");
   let openVisible = $state(false);
   let settingsVisible = $state(false);
+  let aboutVisible = $state(false);
   let zenMode = $state(false);
   let rawMode = $state(false);
 
@@ -54,7 +56,7 @@
   // ESC handler. Each modal's own ESC handler also calls stopPropagation(); the
   // two together cover both focus-inside and focus-outside-modal cases.
   let anyModalVisible = $derived(
-    searchVisible || pasteVisible || openVisible || settingsVisible || lightboxVisible
+    searchVisible || pasteVisible || openVisible || settingsVisible || aboutVisible || lightboxVisible
   );
 
   // Reading progress: debounced scroll save + restore guard
@@ -283,6 +285,9 @@
     };
     (window as any).__mdhero_zen = () => {
       zenMode = !zenMode;
+    };
+    (window as any).__mdhero_about = () => {
+      aboutVisible = true;
     };
     (window as any).__mdhero_check_updates = async () => {
       if (get(checkInFlight)) return;
@@ -658,6 +663,7 @@
   <PasteModal bind:visible={pasteVisible} defaultMode={pasteDefaultMode} />
   <OpenDialog bind:visible={openVisible} />
   <SettingsDialog bind:visible={settingsVisible} />
+  <AboutDialog bind:visible={aboutVisible} />
 
   {#if !rendererReady}
     <div class="state-center">


### PR DESCRIPTION
## Summary
- **About dialog (fixes #15):** Replace the macOS-only native `PredefinedMenuItem::about` with a custom in-app About dialog that works on all platforms. Shows app name, version (from `getVersion()`), and GitHub link. Follows the same pattern as the Settings dialog.
- **Reading progress:** Save and restore reading progress per file so users return to where they left off.

## Test plan
- [ ] Click MDHero → About MDHero on Windows/Linux — dialog should appear
- [ ] Dialog shows correct version from `tauri.conf.json`
- [ ] ESC closes the About dialog without closing the tab behind it
- [ ] Clicking backdrop closes the dialog
- [ ] Dark mode styling works correctly
- [ ] On macOS, About menu item still works (now shows in-app dialog instead of native)

🤖 Generated with [Claude Code](https://claude.com/claude-code)