### PR TITLE
feat: in-app download-and-install auto-update (macOS + Windows)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,7 +103,20 @@ jobs:
           # non-PR events. See the comment on that step for why empty strings
           # don't work as a "skip notarization" signal.
           APPLE_SIGNING_IDENTITY: ${{ matrix.platform == 'macos-latest' && (github.event_name == 'pull_request' && '-' || secrets.APPLE_SIGNING_IDENTITY) || '' }}
+          # Updater signing key — present only on non-PR builds (fork PRs can't
+          # access secrets). createUpdaterArtifacts is enabled via the release
+          # config overlay below, also non-PR only, so the two always line up:
+          # a build either creates signed updater artifacts (key + overlay) or
+          # creates none (PR). It never tries to create unsigned ones, which
+          # Tauri would reject.
+          TAURI_SIGNING_PRIVATE_KEY: ${{ github.event_name != 'pull_request' && secrets.TAURI_SIGNING_PRIVATE_KEY || '' }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ github.event_name != 'pull_request' && secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD || '' }}
         with:
+          # On non-PR builds, merge the overlay that turns on
+          # bundle.createUpdaterArtifacts (signed .tar.gz/.sig + latest.json).
+          # Kept out of the base config so PR builds don't try to sign updater
+          # artifacts without a key.
+          args: ${{ github.event_name != 'pull_request' && '--config src-tauri/tauri.release.conf.json' || '' }}
           tagName: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || '' }}
           releaseName: ${{ startsWith(github.ref, 'refs/tags/') && format('MDHero {0}', github.ref_name) || '' }}
           releaseBody: |

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "@tauri-apps/plugin-cli": "^2.4.1",
     "@tauri-apps/plugin-dialog": "^2.7.0",
     "@tauri-apps/plugin-opener": "^2",
+    "@tauri-apps/plugin-process": "~2.3.1",
+    "@tauri-apps/plugin-updater": "~2.10.1",
     "dompurify": "^3.3.3",
     "highlight.js": "^11.11.1",
     "katex": "^0.16.45",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,12 @@ importers:
       '@tauri-apps/plugin-opener':
         specifier: ^2
         version: 2.5.3
+      '@tauri-apps/plugin-process':
+        specifier: ~2.3.1
+        version: 2.3.1
+      '@tauri-apps/plugin-updater':
+        specifier: ~2.10.1
+        version: 2.10.1
       dompurify:
         specifier: ^3.3.3
         version: 3.3.3
@@ -680,6 +686,12 @@ packages:
 
   '@tauri-apps/plugin-opener@2.5.3':
     resolution: {integrity: sha512-CCcUltXMOfUEArbf3db3kCE7Ggy1ExBEBl51Ko2ODJ6GDYHRp1nSNlQm5uNCFY5k7/ufaK5Ib3Du/Zir19IYQQ==}
+
+  '@tauri-apps/plugin-process@2.3.1':
+    resolution: {integrity: sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==}
+
+  '@tauri-apps/plugin-updater@2.10.1':
+    resolution: {integrity: sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA==}
 
   '@types/cookie@0.6.0':
     resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
@@ -1916,6 +1928,14 @@ snapshots:
       '@tauri-apps/api': 2.10.1
 
   '@tauri-apps/plugin-opener@2.5.3':
+    dependencies:
+      '@tauri-apps/api': 2.10.1
+
+  '@tauri-apps/plugin-process@2.3.1':
+    dependencies:
+      '@tauri-apps/api': 2.10.1
+
+  '@tauri-apps/plugin-updater@2.10.1':
     dependencies:
       '@tauri-apps/api': 2.10.1
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -98,6 +98,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -749,6 +758,17 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1657,6 +1677,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2226,6 +2261,8 @@ dependencies = [
  "tauri-plugin-cli",
  "tauri-plugin-dialog",
  "tauri-plugin-opener",
+ "tauri-plugin-process",
+ "tauri-plugin-updater",
 ]
 
 [[package]]
@@ -2248,6 +2285,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
 
 [[package]]
 name = "miniz_oxide"
@@ -2498,6 +2541,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2560,6 +2615,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2573,6 +2634,20 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3214,15 +3289,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3259,6 +3339,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3287,6 +3381,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3299,6 +3466,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3357,6 +3533,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -3749,6 +3948,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "swift-rs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3861,6 +4066,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -4077,6 +4293,49 @@ dependencies = [
  "url",
  "windows",
  "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-process"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
+dependencies = [
+ "tauri",
+ "tauri-plugin",
+]
+
+[[package]]
+name = "tauri-plugin-updater"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+dependencies = [
+ "base64 0.22.1",
+ "dirs",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip",
 ]
 
 [[package]]
@@ -4306,6 +4565,16 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -4613,6 +4882,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4914,6 +5189,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -5583,6 +5867,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5708,6 +6002,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
 name = "zerotrie"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5738,6 +6038,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.13.1",
+ "memchr",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,4 +26,8 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 notify = { version = "7", features = ["macos_fsevent"] }
 notify-debouncer-mini = "0.5"
+tauri-plugin-process = "2"
+
+[target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
+tauri-plugin-updater = "2"
 

--- a/src-tauri/capabilities/desktop.json
+++ b/src-tauri/capabilities/desktop.json
@@ -1,0 +1,15 @@
+{
+  "identifier": "desktop-capability",
+  "platforms": [
+    "macOS",
+    "windows",
+    "linux"
+  ],
+  "windows": [
+    "main"
+  ],
+  "permissions": [
+    "updater:default",
+    "process:default"
+  ]
+}

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -59,17 +59,20 @@ pub fn list_claude_plans() -> Result<Vec<PlanFile>, String> {
 
     let mut plans: Vec<PlanFile> = Vec::new();
 
-    let entries = fs::read_dir(&plans_dir).map_err(|e| format!("Failed to read plans directory: {}", e))?;
+    let entries =
+        fs::read_dir(&plans_dir).map_err(|e| format!("Failed to read plans directory: {}", e))?;
 
     for entry in entries.flatten() {
         let path = entry.path();
         if path.is_file() {
             if let Some(ext) = path.extension() {
                 if ext == "md" || ext == "markdown" {
-                    let name = path.file_name()
+                    let name = path
+                        .file_name()
                         .map(|n| n.to_string_lossy().to_string())
                         .unwrap_or_default();
-                    let modified = entry.metadata()
+                    let modified = entry
+                        .metadata()
                         .ok()
                         .and_then(|m| m.modified().ok())
                         .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
@@ -118,7 +121,13 @@ pub fn list_folder_md_files(folder: String, max_depth: Option<u32>) -> Result<Ve
     Ok(files)
 }
 
-fn collect_md_files(root: &Path, dir: &Path, max_depth: u32, current_depth: u32, files: &mut Vec<MdFile>) {
+fn collect_md_files(
+    root: &Path,
+    dir: &Path,
+    max_depth: u32,
+    current_depth: u32,
+    files: &mut Vec<MdFile>,
+) {
     if current_depth > max_depth {
         return;
     }
@@ -142,7 +151,16 @@ fn collect_md_files(root: &Path, dir: &Path, max_depth: u32, current_depth: u32,
         if path.is_dir() {
             if let Some(name) = path.file_name() {
                 let n = name.to_string_lossy();
-                if matches!(n.as_ref(), "node_modules" | "target" | "dist" | "build" | ".git" | "__pycache__" | "vendor") {
+                if matches!(
+                    n.as_ref(),
+                    "node_modules"
+                        | "target"
+                        | "dist"
+                        | "build"
+                        | ".git"
+                        | "__pycache__"
+                        | "vendor"
+                ) {
                     continue;
                 }
             }
@@ -153,16 +171,19 @@ fn collect_md_files(root: &Path, dir: &Path, max_depth: u32, current_depth: u32,
         if path.is_file() {
             if let Some(ext) = path.extension() {
                 if ext == "md" || ext == "markdown" || ext == "mdown" || ext == "mkd" {
-                    let name = path.file_name()
+                    let name = path
+                        .file_name()
                         .map(|n| n.to_string_lossy().to_string())
                         .unwrap_or_default();
 
                     // Relative path from the root folder
-                    let rel_path = path.strip_prefix(root)
+                    let rel_path = path
+                        .strip_prefix(root)
                         .map(|p| p.to_string_lossy().to_string())
                         .unwrap_or_default();
 
-                    let modified = entry.metadata()
+                    let modified = entry
+                        .metadata()
                         .ok()
                         .and_then(|m| m.modified().ok())
                         .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
@@ -260,8 +281,8 @@ pub fn show_ai_context_menu(
     // current selection (done frontend-side).
     for provider in &providers {
         let submenu_label = format!("Ask {}", provider.name);
-        let submenu = Submenu::new(&app, &submenu_label, has_selection)
-            .map_err(|e| e.to_string())?;
+        let submenu =
+            Submenu::new(&app, &submenu_label, has_selection).map_err(|e| e.to_string())?;
 
         if provider.prompts.is_empty() {
             // Empty submenu would be silently invisible on some platforms;
@@ -279,14 +300,8 @@ pub fn show_ai_context_menu(
         } else {
             for prompt in &provider.prompts {
                 let id = format!("aimenu:template:{}:{}", provider.id, prompt.id);
-                let item = MenuItem::with_id(
-                    &app,
-                    id,
-                    &prompt.name,
-                    has_selection,
-                    None::<&str>,
-                )
-                .map_err(|e| e.to_string())?;
+                let item = MenuItem::with_id(&app, id, &prompt.name, has_selection, None::<&str>)
+                    .map_err(|e| e.to_string())?;
                 submenu.append(&item).map_err(|e| e.to_string())?;
             }
         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -30,6 +30,8 @@ fn get_opened_files(state: tauri::State<'_, OpenedFiles>) -> Vec<String> {
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
+        .plugin(tauri_plugin_process::init())
+        .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_cli::init())
@@ -55,21 +57,31 @@ pub fn run() {
                 if let Some(window) = app_handle.get_webview_window("main") {
                     let id = event.id().as_ref();
                     match id {
-                        "open" => { let _ = window.eval("window.__mdhero_open_file?.()"); }
-                        "paste_md" => { let _ = window.eval("window.__mdhero_paste?.()"); }
-                        "theme" => { let _ = window.eval("window.__mdhero_toggle_theme?.()"); }
-                        "find" => { let _ = window.eval("window.__mdhero_find?.()"); }
-                        "check_updates" => { let _ = window.eval("window.__mdhero_check_updates?.()"); }
-                        "about" => { let _ = window.eval("window.__mdhero_about?.()"); }
+                        "open" => {
+                            let _ = window.eval("window.__mdhero_open_file?.()");
+                        }
+                        "paste_md" => {
+                            let _ = window.eval("window.__mdhero_paste?.()");
+                        }
+                        "theme" => {
+                            let _ = window.eval("window.__mdhero_toggle_theme?.()");
+                        }
+                        "find" => {
+                            let _ = window.eval("window.__mdhero_find?.()");
+                        }
+                        "check_updates" => {
+                            let _ = window.eval("window.__mdhero_check_updates?.()");
+                        }
+                        "about" => {
+                            let _ = window.eval("window.__mdhero_about?.()");
+                        }
                         // AI lookup right-click menu items — forward the
                         // structured ID to the frontend router. JSON-stringify
                         // the ID so embedded colons (and any future special
                         // chars) survive the eval boundary cleanly.
                         s if s.starts_with("aimenu:") => {
-                            let js = format!(
-                                "window.__mdhero_ai_lookup?.({})",
-                                serde_json::json!(s)
-                            );
+                            let js =
+                                format!("window.__mdhero_ai_lookup?.({})", serde_json::json!(s));
                             let _ = window.eval(&js);
                         }
                         _ => {}
@@ -89,7 +101,9 @@ pub fn run() {
 
                 for url in urls {
                     let path = if url.scheme() == "file" {
-                        url.to_file_path().ok().map(|p| p.to_string_lossy().to_string())
+                        url.to_file_path()
+                            .ok()
+                            .map(|p| p.to_string_lossy().to_string())
                     } else {
                         Some(url.to_string())
                     };

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -11,7 +11,13 @@ pub fn create_menu(app: &AppHandle) -> Result<Menu<tauri::Wry>, tauri::Error> {
         true,
         &[
             &MenuItem::with_id(app, "about", "About MDHero", true, None::<&str>)?,
-            &MenuItem::with_id(app, "check_updates", "Check for Updates…", true, None::<&str>)?,
+            &MenuItem::with_id(
+                app,
+                "check_updates",
+                "Check for Updates…",
+                true,
+                None::<&str>,
+            )?,
             &PredefinedMenuItem::separator(app)?,
             &PredefinedMenuItem::hide(app, None)?,
             &PredefinedMenuItem::hide_others(app, None)?,
@@ -27,7 +33,13 @@ pub fn create_menu(app: &AppHandle) -> Result<Menu<tauri::Wry>, tauri::Error> {
         true,
         &[
             &MenuItem::with_id(app, "open", "Open...", true, Some("CmdOrCtrl+O"))?,
-            &MenuItem::with_id(app, "paste_md", "Paste Markdown...", true, Some("CmdOrCtrl+Shift+V"))?,
+            &MenuItem::with_id(
+                app,
+                "paste_md",
+                "Paste Markdown...",
+                true,
+                Some("CmdOrCtrl+Shift+V"),
+            )?,
             &PredefinedMenuItem::separator(app)?,
             &MenuItem::with_id(app, "close", "Close Tab", true, Some("CmdOrCtrl+W"))?,
         ],
@@ -52,7 +64,13 @@ pub fn create_menu(app: &AppHandle) -> Result<Menu<tauri::Wry>, tauri::Error> {
         "View",
         true,
         &[
-            &MenuItem::with_id(app, "theme", "Toggle Theme", true, Some("CmdOrCtrl+Shift+T"))?,
+            &MenuItem::with_id(
+                app,
+                "theme",
+                "Toggle Theme",
+                true,
+                Some("CmdOrCtrl+Shift+T"),
+            )?,
             &PredefinedMenuItem::separator(app)?,
             &PredefinedMenuItem::fullscreen(app, None)?,
         ],

--- a/src-tauri/src/watcher.rs
+++ b/src-tauri/src/watcher.rs
@@ -38,25 +38,32 @@ pub fn start_watching(app: AppHandle, path: String) -> Result<(), String> {
 
     let app_handle = app.clone();
 
-    let mut debouncer = new_debouncer(Duration::from_millis(500), move |res: Result<Vec<notify_debouncer_mini::DebouncedEvent>, notify::Error>| {
-        match res {
-            Ok(events) => {
-                for event in events {
-                    if event.kind == DebouncedEventKind::Any {
-                        // Only emit if the changed file matches our target
-                        if event.path == target_file {
-                            let _ = app_handle.emit("file-changed", serde_json::json!({
-                                "path": event.path.to_string_lossy()
-                            }));
+    let mut debouncer = new_debouncer(
+        Duration::from_millis(500),
+        move |res: Result<Vec<notify_debouncer_mini::DebouncedEvent>, notify::Error>| {
+            match res {
+                Ok(events) => {
+                    for event in events {
+                        if event.kind == DebouncedEventKind::Any {
+                            // Only emit if the changed file matches our target
+                            if event.path == target_file {
+                                let _ = app_handle.emit(
+                                    "file-changed",
+                                    serde_json::json!({
+                                        "path": event.path.to_string_lossy()
+                                    }),
+                                );
+                            }
                         }
                     }
                 }
+                Err(e) => {
+                    eprintln!("Watch error: {:?}", e);
+                }
             }
-            Err(e) => {
-                eprintln!("Watch error: {:?}", e);
-            }
-        }
-    }).map_err(|e| format!("Failed to create watcher: {}", e))?;
+        },
+    )
+    .map_err(|e| format!("Failed to create watcher: {}", e))?;
 
     debouncer
         .watcher()

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -54,6 +54,15 @@
           "takesValue": true
         }
       ]
+    },
+    "updater": {
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDQ4MkY2OUE5MDM5N0ZCQTgKUldTbys1Y0RxV2t2U0d5TUQ5SU42amVWVWlTUGhTRXBydTZnQXNHL0VHNFM4Z2VMazh3Nm9qcDgK",
+      "endpoints": [
+        "https://github.com/vaibhavuk-dev/mdhero/releases/latest/download/latest.json"
+      ],
+      "windows": {
+        "installMode": "passive"
+      }
     }
   }
 }

--- a/src-tauri/tauri.release.conf.json
+++ b/src-tauri/tauri.release.conf.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "bundle": {
+    "createUpdaterArtifacts": true
+  }
+}

--- a/src/lib/components/UpdateBanner.svelte
+++ b/src/lib/components/UpdateBanner.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { updateAvailable, updateDismissed, dismissUpdate } from "$lib/stores/updater";
+  import { installUpdate, updateInstalling, updateProgress, updateError } from "$lib/stores/autoUpdate";
 
   async function openDownload() {
     const target = $updateAvailable?.download || $updateAvailable?.url;
@@ -32,17 +33,33 @@
       </svg>
     </div>
     <div class="banner-text">
-      <span class="banner-title">Update available — <strong>v{$updateAvailable.version}</strong></span>
-      {#if $updateAvailable.notes}
-        <span class="banner-notes" title={$updateAvailable.notes}>{$updateAvailable.notes}</span>
+      {#if $updateInstalling}
+        <span class="banner-title">
+          {#if $updateProgress >= 0}Downloading update… {$updateProgress}%{:else}Installing update…{/if}
+        </span>
+      {:else if $updateError}
+        <span class="banner-title">Update failed</span>
+        <span class="banner-notes" title={$updateError}>{$updateError}</span>
+      {:else}
+        <span class="banner-title">Update available — <strong>v{$updateAvailable.version}</strong></span>
+        {#if $updateAvailable.notes}
+          <span class="banner-notes" title={$updateAvailable.notes}>{$updateAvailable.notes}</span>
+        {/if}
       {/if}
     </div>
     <div class="banner-actions">
-      {#if $updateAvailable.url}
-        <button class="banner-btn link" onclick={openReleaseNotes}>Release notes</button>
+      {#if $updateInstalling}
+        <!-- progress shown in the title while installing -->
+      {:else if $updateError}
+        <button class="banner-btn primary" onclick={openDownload}>Download manually</button>
+        <button class="banner-btn dismiss" onclick={dismissUpdate}>Later</button>
+      {:else}
+        {#if $updateAvailable.url}
+          <button class="banner-btn link" onclick={openReleaseNotes}>Release notes</button>
+        {/if}
+        <button class="banner-btn primary" onclick={installUpdate}>Update now</button>
+        <button class="banner-btn dismiss" onclick={dismissUpdate} title="Dismiss until next release">Later</button>
       {/if}
-      <button class="banner-btn primary" onclick={openDownload}>Download</button>
-      <button class="banner-btn dismiss" onclick={dismissUpdate} title="Dismiss until next release">Later</button>
     </div>
   </div>
 {/if}

--- a/src/lib/components/UpdateToast.svelte
+++ b/src/lib/components/UpdateToast.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { updateAvailable, updateDismissed, dismissUpdate } from "$lib/stores/updater";
+  import { installUpdate, updateInstalling, updateProgress, updateError } from "$lib/stores/autoUpdate";
   import { tabStore, HOME_TAB_ID } from "$lib/stores/tabs";
 
   const { activeTabId } = tabStore;
@@ -25,12 +26,25 @@
         <path d="M3 12v1h10v-1" />
       </svg>
       <span class="update-text">
-        MDHero <strong>v{$updateAvailable.version}</strong> is available
+        {#if $updateInstalling}
+          {#if $updateProgress >= 0}Downloading… {$updateProgress}%{:else}Installing…{/if}
+        {:else if $updateError}
+          Update failed
+        {:else}
+          MDHero <strong>v{$updateAvailable.version}</strong> is available
+        {/if}
       </span>
     </div>
     <div class="update-actions">
-      <button class="update-btn download" onclick={openRelease}>Download</button>
-      <button class="update-btn dismiss" onclick={dismissUpdate}>Later</button>
+      {#if $updateInstalling}
+        <!-- buttons hidden while installing; progress shows in the text -->
+      {:else if $updateError}
+        <button class="update-btn download" onclick={openRelease}>Download manually</button>
+        <button class="update-btn dismiss" onclick={dismissUpdate}>Later</button>
+      {:else}
+        <button class="update-btn download" onclick={installUpdate}>Update now</button>
+        <button class="update-btn dismiss" onclick={dismissUpdate}>Later</button>
+      {/if}
     </div>
   </div>
 {/if}

--- a/src/lib/stores/autoUpdate.ts
+++ b/src/lib/stores/autoUpdate.ts
@@ -1,0 +1,76 @@
+import { writable, get } from "svelte/store";
+
+/**
+ * In-app download + install of updates via tauri-plugin-updater.
+ *
+ * This is the *action* layer. The *detection* layer lives in `updater.ts`
+ * (it polls mdhero.app/api/version, drives the banner/toast, and feeds the
+ * aggregate DAU counter). When the user clicks "Update now," we run the
+ * updater plugin's own check against the GitHub `latest.json` manifest —
+ * that's authoritative for the signed artifact — then download, install, and
+ * relaunch onto the new version.
+ */
+
+/** True while a download/install is in progress. */
+export const updateInstalling = writable(false);
+/** 0–100 once content length is known; -1 while indeterminate. */
+export const updateProgress = writable(-1);
+/** Human-readable error if the install failed (null = no error). */
+export const updateError = writable<string | null>(null);
+
+export async function installUpdate(): Promise<void> {
+  // The updater plugin is a no-op in dev (no bundled app to replace). Surface
+  // a clear message rather than failing cryptically.
+  if (import.meta.env.DEV) {
+    updateError.set("In-app updates are only available in installed builds, not dev.");
+    return;
+  }
+
+  if (get(updateInstalling)) return;
+
+  updateError.set(null);
+  updateInstalling.set(true);
+  updateProgress.set(-1);
+
+  try {
+    const { check } = await import("@tauri-apps/plugin-updater");
+    const update = await check();
+
+    if (!update) {
+      updateError.set("No update available.");
+      updateInstalling.set(false);
+      return;
+    }
+
+    let downloaded = 0;
+    let contentLength = 0;
+
+    await update.downloadAndInstall((event) => {
+      switch (event.event) {
+        case "Started":
+          contentLength = event.data.contentLength ?? 0;
+          downloaded = 0;
+          updateProgress.set(contentLength > 0 ? 0 : -1);
+          break;
+        case "Progress":
+          downloaded += event.data.chunkLength;
+          if (contentLength > 0) {
+            updateProgress.set(Math.min(100, Math.round((downloaded / contentLength) * 100)));
+          }
+          break;
+        case "Finished":
+          updateProgress.set(100);
+          break;
+      }
+    });
+
+    // Installed to disk — relaunch onto the new version. On Windows the NSIS
+    // installer (installMode: passive) handles the swap + relaunch itself, so
+    // this may not return; calling relaunch is still correct on macOS.
+    const { relaunch } = await import("@tauri-apps/plugin-process");
+    await relaunch();
+  } catch (err) {
+    updateError.set(err instanceof Error ? err.message : String(err));
+    updateInstalling.set(false);
+  }
+}


### PR DESCRIPTION
## What this does

Replaces the update banner/toast **"Download"** link with **"Update now"** — the app downloads the new release, verifies its signature, installs it, and relaunches. Sparkle-grade UX, cross-platform (macOS + Windows), via `tauri-plugin-updater` + `tauri-plugin-process`.

This is the **bootstrap release** for auto-update: it's forward-only, so existing v0.2.5 users do one last manual update to get here; everyone from v0.2.6 onward updates in-app.

## How it works

Two layers, deliberately separated:

- **Detection** (existing `updater.ts`) — polls `mdhero.app/api/version`, drives the banner/toast and the DAU counter. Unchanged.
- **Action** (new `autoUpdate.ts`) — on "Update now", runs the updater plugin's own `check()` against the GitHub `latest.json` manifest (authoritative for the signed artifact), then `downloadAndInstall()` with progress → `relaunch()`. DEV-guarded (no-op in dev with a clear message).

## Changes

- `Cargo.toml` / `package.json` — add `tauri-plugin-updater` + `tauri-plugin-process` (+ JS pkgs)
- `lib.rs` — register both plugins
- `capabilities/desktop.json` — `updater:default` + `process:default` permissions
- `tauri.conf.json` — `plugins.updater`: public key, GitHub `latest.json` endpoint, Windows `installMode: passive`
- `tauri.release.conf.json` (new) — overlay enabling `bundle.createUpdaterArtifacts`, merged on release builds only
- `autoUpdate.ts` (new) — `installUpdate()` + `updateInstalling` / `updateProgress` / `updateError` stores
- `UpdateBanner.svelte` / `UpdateToast.svelte` — "Update now" + progress UI + manual-download fallback on error
- `build.yml` — pass the signing key + the release overlay, both gated to **non-PR** events (mirrors the Apple-signing gate, so fork PRs never try to produce unsigned updater artifacts)

## Validation status

- ✅ `cargo check` + `pnpm check` clean
- ✅ CI on this PR proves the app builds in release context
- ⚠️ **The signing pipeline (`latest.json` + `.sig` generation) only runs on a tag push** — it's deliberately skipped on PR builds (no secrets on forks). First real check: confirm those assets appear on the **v0.2.6** GitHub release. Full end-to-end auto-update (install v0.2.6 → in-app update to v0.2.7) can only be tested once two releases exist.

## Notes

- Windows is unsigned (no Authenticode) → the passive NSIS installer may show a UAC prompt. Acceptable; only Authenticode signing removes it (separate effort).
- The signing private key lives in GitHub Actions secrets; only the public key is in the repo.
