### PR TITLE
fix: wrap-aware, fractional scroll sync for raw/editor (#21)

### DIFF
--- a/src/lib/utils/scroll-sync.ts
+++ b/src/lib/utils/scroll-sync.ts
@@ -2,12 +2,15 @@
  * Scroll synchronization across viewer / raw / editor modes.
  *
  * Strategy: anchor on the source markdown's line number. The renderer stamps
- * `data-source-line="N"` on every top-level block element. Raw and editor
- * use lineHeight × scrollTop to estimate the line.
+ * `data-source-line="N"` (0-indexed) on every top-level block element. The
+ * viewer reads/writes those stamps directly via getBoundingClientRect.
  *
- * Limitation: long lines that visually wrap are counted as a single source line
- * but occupy multiple visual rows. For typical markdown documents the drift is
- * small; if it ever matters we can add a hidden mirror-div line measurer.
+ * Raw and editor have no per-line DOM, so we map source line ↔ pixel offset
+ * through `measureLineOffsets`: an off-screen mirror that replicates the
+ * element's content width, font, and wrapping rules and reports each line's
+ * real `offsetTop`. This is wrap-aware — a flat `line * lineHeight` is wrong
+ * the moment a long line wraps to multiple visual rows (issue #21), which is
+ * exactly the case both panes hit since they `white-space: pre-wrap`.
  */
 
 export type ViewMode = "viewer" | "raw" | "editor";
@@ -45,38 +48,46 @@ function readViewerLine(): number {
   const elements = article.querySelectorAll<HTMLElement>("[data-source-line]");
   if (elements.length === 0) return 0;
 
-  // Find the topmost element whose bottom is below the chrome line.
-  // That is the block currently "in view" at the top.
+  // Topmost block whose bottom is below the chrome line is the one "in view".
+  // Return its start line PLUS the fraction of the block scrolled above the
+  // chrome line — the fraction is what keeps your place when one block wraps
+  // across many rows (issue #21); without it, deep-in-a-block positions snap
+  // back to the block's first line on a mode switch.
   for (const el of elements) {
     const rect = el.getBoundingClientRect();
     if (rect.bottom > TOOLBAR_TABBAR_HEIGHT) {
-      return parseInt(el.getAttribute("data-source-line") || "0", 10);
+      const frac =
+        rect.height > 0 ? clamp01((TOOLBAR_TABBAR_HEIGHT - rect.top) / rect.height) : 0;
+      return lineOf(el) + frac;
     }
   }
   // Past the end — return the last block's line
-  const last = elements[elements.length - 1];
-  return parseInt(last.getAttribute("data-source-line") || "0", 10);
+  return lineOf(elements[elements.length - 1]);
 }
 
-function scrollViewerToLine(line: number): void {
+function scrollViewerToLine(anchor: number): void {
   const article = document.querySelector("article.prose");
   if (!article) return;
   const elements = Array.from(article.querySelectorAll<HTMLElement>("[data-source-line]"));
   if (elements.length === 0) return;
 
-  // Find the element at or just past the target line
-  let target: HTMLElement | null = null;
+  const floor = Math.floor(anchor);
+  const frac = anchor - floor;
+
+  // The block at or just before the target line; the fraction then positions
+  // the viewport within that block to mirror the source mode.
+  let target = elements[0];
   for (const el of elements) {
-    const elLine = parseInt(el.getAttribute("data-source-line") || "0", 10);
-    if (elLine >= line) {
-      target = el;
-      break;
-    }
+    if (lineOf(el) <= floor) target = el;
+    else break;
   }
-  if (!target) target = elements[elements.length - 1];
 
   const rect = target.getBoundingClientRect();
-  window.scrollTo(0, window.scrollY + rect.top - TOOLBAR_TABBAR_HEIGHT);
+  window.scrollTo(0, window.scrollY + rect.top + frac * rect.height - TOOLBAR_TABBAR_HEIGHT);
+}
+
+function lineOf(el: HTMLElement): number {
+  return parseInt(el.getAttribute("data-source-line") || "0", 10);
 }
 
 // --- Raw (window-scrolled <pre class="raw-source">) ---
@@ -84,20 +95,19 @@ function scrollViewerToLine(line: number): void {
 function readRawLine(): number {
   const pre = document.querySelector<HTMLPreElement>(".raw-source");
   if (!pre) return 0;
-  const lineHeight = parseFloat(getComputedStyle(pre).lineHeight) || 16;
   const preTop = pre.getBoundingClientRect().top;
-  // pixels of pre that have scrolled above the chrome line
+  // pixels of the pre's content that have scrolled above the chrome line
   const hidden = TOOLBAR_TABBAR_HEIGHT - preTop;
   if (hidden <= 0) return 0;
-  return Math.floor(hidden / lineHeight);
+  return fractionalLineAtOffset(measureLineOffsets(pre, pre.textContent || ""), hidden);
 }
 
-function scrollRawToLine(line: number): void {
+function scrollRawToLine(anchor: number): void {
   const pre = document.querySelector<HTMLPreElement>(".raw-source");
   if (!pre) return;
-  const lineHeight = parseFloat(getComputedStyle(pre).lineHeight) || 16;
+  const offsets = measureLineOffsets(pre, pre.textContent || "");
   const preTopAbsolute = pre.getBoundingClientRect().top + window.scrollY;
-  window.scrollTo(0, preTopAbsolute + line * lineHeight - TOOLBAR_TABBAR_HEIGHT);
+  window.scrollTo(0, preTopAbsolute + pixelAtLine(offsets, anchor) - TOOLBAR_TABBAR_HEIGHT);
 }
 
 // --- Editor (textarea with internal scroll) ---
@@ -109,13 +119,126 @@ function getEditorEl(): HTMLTextAreaElement | null {
 function readEditorLine(): number {
   const ta = getEditorEl();
   if (!ta) return 0;
-  const lineHeight = parseFloat(getComputedStyle(ta).lineHeight) || 16;
-  return Math.floor(ta.scrollTop / lineHeight);
+  return fractionalLineAtOffset(measureLineOffsets(ta, ta.value), ta.scrollTop);
 }
 
-function scrollEditorToLine(line: number): void {
+function scrollEditorToLine(anchor: number): void {
   const ta = getEditorEl();
   if (!ta) return;
-  const lineHeight = parseFloat(getComputedStyle(ta).lineHeight) || 16;
-  ta.scrollTop = Math.round(line * lineHeight);
+  const offsets = measureLineOffsets(ta, ta.value);
+  ta.scrollTop = Math.round(pixelAtLine(offsets, anchor));
+}
+
+// --- Wrap-aware, fractional line ↔ pixel mapping ---
+//
+// Anchors are fractional: the integer part is the 0-based source line at the
+// top, the fractional part is how far the viewport has scrolled INTO that
+// line's wrapped rows (0 = line top, →1 = next line top). The fraction is what
+// preserves position inside a tall block across a mode switch (issue #21).
+
+function clamp01(x: number): number {
+  return x < 0 ? 0 : x > 1 ? 1 : x;
+}
+
+function clampLine(line: number, count: number): number {
+  if (count === 0) return 0;
+  return Math.min(Math.max(line, 0), count - 1);
+}
+
+/** Largest index `i` with `offsets[i] <= y` (binary search). */
+function lineAtOffset(offsets: number[], y: number): number {
+  if (offsets.length === 0 || y <= 0) return 0;
+  let lo = 0;
+  let hi = offsets.length - 1;
+  let ans = 0;
+  while (lo <= hi) {
+    const mid = (lo + hi) >> 1;
+    if (offsets[mid] <= y) {
+      ans = mid;
+      lo = mid + 1;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  return ans;
+}
+
+/** Fractional source line at pixel `y`: integer line + fraction into its rows. */
+function fractionalLineAtOffset(offsets: number[], y: number): number {
+  if (offsets.length === 0 || y <= 0) return 0;
+  const floor = lineAtOffset(offsets, y);
+  const base = offsets[floor];
+  const next = floor + 1 < offsets.length ? offsets[floor + 1] : base + 1;
+  const span = next - base;
+  return floor + (span > 0 ? clamp01((y - base) / span) : 0);
+}
+
+/** Inverse of `fractionalLineAtOffset`: pixel offset for a fractional line. */
+function pixelAtLine(offsets: number[], anchor: number): number {
+  if (offsets.length === 0) return 0;
+  const floor = clampLine(Math.floor(anchor), offsets.length);
+  const frac = anchor - Math.floor(anchor);
+  const base = offsets[floor];
+  const next = floor + 1 < offsets.length ? offsets[floor + 1] : base;
+  return base + (frac > 0 ? frac * (next - base) : 0);
+}
+
+/**
+ * Measure the top pixel offset of every source line as it actually wraps
+ * inside `reference` (the raw <pre> or the editor <textarea>). Returns an array
+ * where `offsets[i]` is the y of line `i`'s first visual row, relative to the
+ * content's top.
+ *
+ * Why a mirror: a <textarea> exposes no per-line geometry, and a wrapped <pre>'s
+ * lines don't map to `lineHeight`. We replicate the element's content width,
+ * font metrics, and wrap rules off-screen and read each line's real `offsetTop`.
+ * Called once per mode switch, so a single layout pass is fine.
+ */
+function measureLineOffsets(reference: HTMLElement, text: string): number[] {
+  const cs = getComputedStyle(reference);
+  const padL = parseFloat(cs.paddingLeft) || 0;
+  const padR = parseFloat(cs.paddingRight) || 0;
+  const contentWidth = reference.clientWidth - padL - padR;
+
+  const mirror = document.createElement("div");
+  const s = mirror.style;
+  s.position = "absolute";
+  s.left = "-9999px";
+  s.top = "0";
+  s.visibility = "hidden";
+  s.boxSizing = "border-box";
+  s.margin = "0";
+  s.padding = "0";
+  s.border = "0";
+  s.width = `${Math.max(0, contentWidth)}px`;
+  // Replicate text metrics so wrapping matches the reference exactly.
+  s.fontFamily = cs.fontFamily;
+  s.fontSize = cs.fontSize;
+  s.fontWeight = cs.fontWeight;
+  s.fontStyle = cs.fontStyle;
+  s.lineHeight = cs.lineHeight;
+  s.letterSpacing = cs.letterSpacing;
+  s.tabSize = cs.tabSize;
+  s.whiteSpace = "pre-wrap";
+  s.wordBreak = cs.wordBreak;
+  s.overflowWrap = cs.overflowWrap;
+
+  const lines = text.split("\n");
+  const markers: HTMLElement[] = new Array(lines.length);
+  const frag = document.createDocumentFragment();
+  for (let i = 0; i < lines.length; i++) {
+    const row = document.createElement("div");
+    row.style.whiteSpace = "pre-wrap";
+    row.style.wordBreak = cs.wordBreak;
+    row.style.overflowWrap = cs.overflowWrap;
+    // Empty lines must still occupy one row; a zero-width space forces a line box.
+    row.textContent = lines[i].length ? lines[i] : "\u200b";
+    frag.appendChild(row);
+    markers[i] = row;
+  }
+  mirror.appendChild(frag);
+  document.body.appendChild(mirror);
+  const offsets = markers.map((m) => m.offsetTop);
+  document.body.removeChild(mirror);
+  return offsets;
 }

--- a/tests/fixtures/scroll-sync-wrap.md
+++ b/tests/fixtures/scroll-sync-wrap.md
@@ -1,0 +1,57 @@
+# Scroll-sync wrap test (issue #21)
+
+**How to test:** Stay in Reading mode and scroll down so one of the
+`## Section N` headings sits at the very top of the viewport. Toggle to
+**Raw** (`</>`), then to **Edit** (pencil). Each time, the same section
+should be anchored at the top — you should see `## Section N` and a wall of
+`secN secN …`, **not** Section 1's `sec1`. Before the fix it snaps near the
+top (Section 1); after the fix it lands on the section you were reading.
+
+The long line in each section is a *single* source line that wraps into many
+visual rows — that wrapping is exactly what the old `line * lineHeight` math
+got wrong. The repeated word tells you which section you're actually on.
+
+---
+
+## Section 1
+
+Short normal paragraph for section 1. This line does not wrap, so it exercises the simple case alongside the long one below it.
+
+sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 sec1 
+
+## Section 2
+
+Short normal paragraph for section 2. This line does not wrap, so it exercises the simple case alongside the long one below it.
+
+sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 sec2 
+
+## Section 3
+
+Short normal paragraph for section 3. This line does not wrap, so it exercises the simple case alongside the long one below it.
+
+sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 sec3 
+
+## Section 4
+
+Short normal paragraph for section 4. This line does not wrap, so it exercises the simple case alongside the long one below it.
+
+sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 sec4 
+
+## Section 5
+
+Short normal paragraph for section 5. This line does not wrap, so it exercises the simple case alongside the long one below it.
+
+sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 sec5 
+
+## Section 6
+
+Short normal paragraph for section 6. This line does not wrap, so it exercises the simple case alongside the long one below it.
+
+sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 sec6 
+
+## Section 7
+
+Short normal paragraph for section 7. This line does not wrap, so it exercises the simple case alongside the long one below it.
+
+sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 sec7 
+


### PR DESCRIPTION
Fixes #21.

## The bug
Switching Reading → Raw/Edit on a long document landed near the top instead of at your reading position. Reporter's repro: paragraphs where each is one very long line that wraps to ~40 rows.

## Root cause
`scroll-sync.ts` mapped source line ↔ pixels with flat `line * lineHeight`, which assumes **one source line = one visual row**. But both panes wrap (`.raw-source` is `white-space: pre-wrap`; the editor `<textarea>` soft-wraps), so a line wrapping to K rows threw the estimate off by `(K−1) × lineHeight` for every wrapped line above the target.

A second, related issue: `data-source-line` only marks each block's *start*, so a position **deep inside** one tall wrapped block snapped back to the block's first line on switch.

## The fix
- **`measureLineOffsets()`** — an off-screen mirror replicating the pane's content width, font metrics, and wrap rules; reads each source line's real `offsetTop`. Replaces the `lineHeight` arithmetic in both directions.
- **Fractional anchors** — anchors now carry "line N **+ how far through that block**," so deep-in-a-block positions survive a mode switch. Viewer uses the block's rect fraction; raw/editor interpolate between measured offsets.

Viewer logic is untouched (it was already accurate via `getBoundingClientRect`).

## Verification
- `tests/fixtures/scroll-sync-wrap.md` (added) — 7 labeled sections each with a heavily-wrapping long line; self-test steps at the top. Reporter can verify on Windows with the identical file.
- Confirmed locally: lands at the correct spot, the jump is gone.
- `pnpm check` clean (no new errors); change is frontend-only.

## Known limit
The fraction is mapped proportionally, and Reading renders prose while Raw/Edit render monospace, so wrap counts differ slightly — on pathological 220-word single-line paragraphs it lands very close but not pixel-identical. For normal-length lines it's spot-on.
