### PR TITLE
fix: enable local image assets

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1651,6 +1651,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4102,6 +4108,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
+ "http-range",
  "jni",
  "libc",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = [] }
+tauri = { version = "2", features = ["protocol-asset"] }
 tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-cli = "2"

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -49,6 +49,25 @@ pub fn write_markdown_file(path: String, content: String) -> Result<(), String> 
 }
 
 #[tauri::command]
+pub fn resolve_path(path: String) -> Result<String, String> {
+    let p = Path::new(&path);
+    let absolute = if p.is_absolute() {
+        p.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map_err(|e| format!("Failed to determine current directory: {}", e))?
+            .join(p)
+    };
+
+    absolute
+        .canonicalize()
+        .unwrap_or(absolute)
+        .to_str()
+        .map(|s| s.to_string())
+        .ok_or_else(|| format!("Path is not valid UTF-8: {}", path))
+}
+
+#[tauri::command]
 pub fn list_claude_plans() -> Result<Vec<PlanFile>, String> {
     let home = std::env::var("HOME").map_err(|_| "Cannot determine home directory".to_string())?;
     let plans_dir = Path::new(&home).join(".claude").join("plans");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -40,6 +40,7 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             commands::read_markdown_file,
             commands::write_markdown_file,
+            commands::resolve_path,
             commands::list_claude_plans,
             commands::list_folder_md_files,
             commands::quit_app,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -21,7 +21,11 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": null,
+      "assetProtocol": {
+        "enable": true,
+        "scope": ["**"]
+      }
     }
   },
   "bundle": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -24,7 +24,10 @@
       "csp": null,
       "assetProtocol": {
         "enable": true,
-        "scope": ["**"]
+        "scope": {
+          "requireLiteralLeadingDot": false,
+          "allow": ["$HOME/**/*"]
+        }
       }
     }
   },

--- a/src/lib/renderer/pipeline.ts
+++ b/src/lib/renderer/pipeline.ts
@@ -224,9 +224,35 @@ function resolveRelativeImages(html: string, baseDir: string): string {
         return `${before}${src}${after}`;
       }
     }
+  ).replace(
+    /(<(?:img|source)\s[^>]*?\bsrcset=")([^"]+)(")/gi,
+    (_match, before, srcset, after) => `${before}${resolveSrcset(srcset, baseDir)}${after}`
   );
 }
 
+function resolveSrcset(srcset: string, baseDir: string): string {
+  return srcset
+    .split(",")
+    .map((candidate) => {
+      const trimmed = candidate.trim();
+      if (!trimmed) return trimmed;
+
+      const [src, ...descriptor] = trimmed.split(/\s+/);
+      if (isExternalSrc(src)) return trimmed;
+
+      try {
+        const converted = convertFileSrc(resolveImagePath(src, baseDir));
+        return [converted, ...descriptor].join(" ");
+      } catch {
+        return trimmed;
+      }
+    })
+    .join(", ");
+}
+
+function isExternalSrc(src: string): boolean {
+  return /^(?:https?:\/\/|data:|blob:|asset:|file:)/i.test(src);
+}
 function resolveImagePath(src: string, baseDir: string): string {
   const decodedSrc = decodeImageSrc(src);
   if (isAbsolutePath(decodedSrc)) return decodedSrc;

--- a/src/lib/renderer/pipeline.ts
+++ b/src/lib/renderer/pipeline.ts
@@ -215,16 +215,54 @@ export function renderFull(markdown: string, baseDir?: string): RenderResult {
 
 function resolveRelativeImages(html: string, baseDir: string): string {
   return html.replace(
-    /(<img\s[^>]*?\bsrc=")(?!https?:\/\/|data:|blob:)([^"]+)(")/gi,
+    /(<img\s[^>]*?\bsrc=")(?!https?:\/\/|data:|blob:|asset:|file:)([^"]+)(")/gi,
     (_match, before, src, after) => {
-      const absPath = `${baseDir}/${src}`.replace(/\/\.\//g, "/");
+      const imagePath = resolveImagePath(src, baseDir);
       try {
-        return `${before}${convertFileSrc(absPath)}${after}`;
+        return `${before}${convertFileSrc(imagePath)}${after}`;
       } catch {
         return `${before}${src}${after}`;
       }
     }
   );
+}
+
+function resolveImagePath(src: string, baseDir: string): string {
+  const decodedSrc = decodeImageSrc(src);
+  if (isAbsolutePath(decodedSrc)) return decodedSrc;
+  return normalizePath(`${baseDir}/${decodedSrc}`);
+}
+
+function decodeImageSrc(src: string): string {
+  try {
+    return decodeURI(src);
+  } catch {
+    return src;
+  }
+}
+
+function isAbsolutePath(path: string): boolean {
+  return path.startsWith("/") || /^[a-zA-Z]:[\\/]/.test(path) || path.startsWith("\\\\");
+}
+
+function normalizePath(path: string): string {
+  const isWindowsPath = /^[a-zA-Z]:[\\/]/.test(path) || path.startsWith("\\\\");
+  const separator = isWindowsPath ? "\\" : "/";
+  const normalized = path.replace(/[\\/]+/g, separator);
+  const prefix = normalized.startsWith(separator) ? separator : "";
+  const parts = normalized.split(separator);
+  const stack: string[] = [];
+
+  for (const part of parts) {
+    if (!part || part === ".") continue;
+    if (part === ".." && stack.length > 0 && stack[stack.length - 1] !== "..") {
+      stack.pop();
+    } else if (part !== ".." || !prefix) {
+      stack.push(part);
+    }
+  }
+
+  return `${prefix}${stack.join(separator)}`;
 }
 
 export function isInitialized(): boolean {

--- a/src/lib/tauri/files.ts
+++ b/src/lib/tauri/files.ts
@@ -15,10 +15,12 @@ export async function saveFile(path: string, content: string): Promise<void> {
 }
 
 export async function openFile(path: string): Promise<void> {
-  const fileName = path.split("/").pop() ?? path;
+  const absolutePath = await resolvePath(path);
+  const fileName = absolutePath.split("/").pop() ?? absolutePath;
+  const baseDir = getBaseDir(absolutePath);
 
   document.set({
-    filePath: path,
+    filePath: absolutePath,
     fileName,
     content: "",
     renderedHtml: "",
@@ -29,14 +31,13 @@ export async function openFile(path: string): Promise<void> {
   });
 
   try {
-    const content = await readMarkdownFile(path);
-    const baseDir = path.includes("/") ? path.substring(0, path.lastIndexOf("/")) : undefined;
+    const content = await readMarkdownFile(absolutePath);
     const result = renderFull(content, baseDir);
 
-    tabStore.addTab(path, fileName, content, result.html, result.frontmatter, result.wordCount);
+    tabStore.addTab(absolutePath, fileName, content, result.html, result.frontmatter, result.wordCount);
 
     document.set({
-      filePath: path,
+      filePath: absolutePath,
       fileName,
       content,
       renderedHtml: result.html,
@@ -46,12 +47,12 @@ export async function openFile(path: string): Promise<void> {
       error: null,
     });
 
-    addRecentFile(path, fileName);
+    addRecentFile(absolutePath, fileName);
     getCurrentWindow().setTitle(`${fileName} — MDHero`).catch(() => {});
-    invoke("start_watching", { path }).catch(() => {});
+    invoke("start_watching", { path: absolutePath }).catch(() => {});
   } catch (err) {
     document.set({
-      filePath: path,
+      filePath: absolutePath,
       fileName,
       content: "",
       renderedHtml: "",
@@ -87,15 +88,16 @@ export async function openFileDialog(): Promise<void> {
 
 export async function reloadCurrentFile(path: string): Promise<void> {
   try {
-    const content = await readMarkdownFile(path);
-    const baseDir = path.substring(0, path.lastIndexOf("/"));
+    const absolutePath = await resolvePath(path);
+    const content = await readMarkdownFile(absolutePath);
+    const baseDir = getBaseDir(absolutePath);
     const result = renderFull(content, baseDir);
-    const fileName = path.split("/").pop() ?? path;
+    const fileName = absolutePath.split("/").pop() ?? absolutePath;
 
-    tabStore.updateTabContent(path, content, result.html, result.frontmatter, result.wordCount);
+    tabStore.updateTabContent(absolutePath, content, result.html, result.frontmatter, result.wordCount);
 
     document.set({
-      filePath: path,
+      filePath: absolutePath,
       fileName,
       content,
       renderedHtml: result.html,
@@ -107,4 +109,14 @@ export async function reloadCurrentFile(path: string): Promise<void> {
   } catch (err) {
     console.error("Failed to reload file:", err);
   }
+}
+
+export function getBaseDir(path: string): string {
+  const normalized = path.replace(/\\/g, "/");
+  const idx = normalized.lastIndexOf("/");
+  return idx >= 0 ? normalized.slice(0, idx) : ".";
+}
+
+export async function resolvePath(path: string): Promise<string> {
+  return invoke<string>("resolve_path", { path });
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,7 +3,7 @@
   import { document as docStore } from "$lib/stores/document";
   import { tabStore, HOME_TAB_ID, type Tab } from "$lib/stores/tabs";
   import { initRenderer, renderFull } from "$lib/renderer/pipeline";
-  import { openFile, openFileDialog, saveFile } from "$lib/tauri/files";
+  import { getBaseDir, openFile, openFileDialog, saveFile } from "$lib/tauri/files";
   import { settings } from "$lib/stores/settings";
   import { startFileWatcher } from "$lib/tauri/watcher";
   import { themeMode, cycleTheme } from "$lib/stores/theme";
@@ -171,9 +171,7 @@
       // shows the latest unsaved changes immediately. The dirty indicator
       // continues to mark that the changes aren't on disk yet.
       if (activeTab.isEditing && activeTab.dirty) {
-        const baseDir = activeTab.filePath.includes("/")
-          ? activeTab.filePath.substring(0, activeTab.filePath.lastIndexOf("/"))
-          : undefined;
+        const baseDir = getBaseDir(activeTab.filePath);
         const result = renderFull(activeTab.editContent, baseDir);
         // Update the rendered HTML in the docStore so the viewer reflects
         // the unsaved edits. We do NOT call tabStore.updateTabContent or
@@ -207,9 +205,7 @@
     if (!tab.dirty) return;
     try {
       await saveFile(tab.filePath, tab.editContent);
-      const baseDir = tab.filePath.includes("/")
-        ? tab.filePath.substring(0, tab.filePath.lastIndexOf("/"))
-        : undefined;
+      const baseDir = getBaseDir(tab.filePath);
       const result = renderFull(tab.editContent, baseDir);
       tabStore.markSaved(tab.id);
       tabStore.updateTabContent(


### PR DESCRIPTION
Enable Tauri's asset protocol so convertFileSrc URLs can be loaded by the webview. 
Address issue: https://github.com/vaibhavuk-dev/mdhero/pull/23

Resolve markdown image sources against the opened document directory, preserving absolute paths and normalizing relative ./ and ../ segments before converting them to asset URLs.

## Summary

<!-- What does this PR do? Keep it brief. -->

## Changes

<!-- Bullet list of specific changes -->

-

## Testing

<!-- How did you verify this works? -->

- [ ] Tested in dev mode (`pnpm tauri dev`)
- [ ] Works in both light and dark mode
- [ ] No regressions in existing features
- [ ] `pnpm check` passes
