### PR TITLE
Enable markdown HTML rendering

### DIFF
--- a/src/lib/renderer/pipeline.ts
+++ b/src/lib/renderer/pipeline.ts
@@ -87,7 +87,7 @@ export async function initRenderer(): Promise<void> {
   if (initialized) return;
 
   md = new MarkdownIt({
-    html: false,
+    html: true,
     linkify: true,
     typographer: true,
     highlight: (str, lang) => {
@@ -131,7 +131,7 @@ export function renderFull(markdown: string, baseDir?: string): RenderResult {
   if (!md) {
     // Auto-init synchronously if not yet initialized
     md = new MarkdownIt({
-    html: false,
+    html: true,
     linkify: true,
     typographer: true,
     highlight: (str, lang) => {


### PR DESCRIPTION
   HTML Rendering PR

  ## Summary

  Enables inline HTML rendering in Markdown documents while preserving the existing
  DOMPurify sanitization step.

  ## Changes

  - Enables `markdown-it` HTML parsing by setting `html: true`.
  - Applies the same setting in both renderer initialization paths.
  - Allows trusted Markdown content such as layout spacer `<div>` elements to render instead
  of appearing as escaped text.

  ## Testing

  - [x] Verified with `pnpm build`
  - [ ] Tested in dev mode (`pnpm tauri dev`)
  - [ ] Works in both light and dark mode
  - [ ] No regressions in existing features
  - [ ] `pnpm check` passes
