### PR TITLE
Add Vim-style Ctrl-F and Ctrl-B paging

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -412,7 +412,29 @@
     }
   }
 
+  function scrollPage(direction: "up" | "down") {
+    const distance = window.innerHeight * (direction === "down" ? 1 : -1);
+    window.scrollBy({ top: distance, behavior: "smooth" });
+  }
+
   function handleKeydown(e: KeyboardEvent) {
+    // Vim-style Ctrl+F / Ctrl+B full-page navigation in reader/raw modes.
+    // Keep this before the generic Cmd/Ctrl shortcut block so Ctrl+F does not
+    // fall through to the browser/WebView find behavior.
+    if (
+      e.ctrlKey
+      && !e.metaKey
+      && !e.altKey
+      && !e.shiftKey
+      && (e.key === "f" || e.key === "b")
+    ) {
+      if (!isInputFocused() && !anyModalVisible && !activeTab?.isEditing && $docStore.renderedHtml) {
+        e.preventDefault();
+        scrollPage(e.key === "f" ? "down" : "up");
+      }
+      return;
+    }
+
     // Cmd+1-9 tab switching
     if ((e.metaKey || e.ctrlKey) && e.key >= "1" && e.key <= "9") {
       e.preventDefault();


### PR DESCRIPTION
  Ctrl-F / Ctrl-B PR

  ## Summary

  Adds Vim-style full-page navigation shortcuts for reading Markdown documents.

  ## Changes

  - Adds `Ctrl+F` to scroll one page down.
  - Adds `Ctrl+B` to scroll one page up.
  - Limits these shortcuts to reader/raw modes.
  - Avoids intercepting shortcuts while editing, typing in inputs, or using modals.

  ## Testing

  - [x] Verified with `pnpm build`
  - [ ] Tested in dev mode (`pnpm tauri dev`)
  - [ ] Works in both light and dark mode
  - [ ] No regressions in existing features
  - [ ] `pnpm check` passes