### PR TITLE
fix: load local images outside $HOME via runtime asset allow (#31)

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -67,6 +67,25 @@ pub fn resolve_path(path: String) -> Result<String, String> {
         .ok_or_else(|| format!("Path is not valid UTF-8: {}", path))
 }
 
+/// Allow the webview's asset protocol to serve specific image files.
+///
+/// The static `assetProtocol.scope` in tauri.conf.json only covers `$HOME`, so
+/// documents opened from elsewhere (external drives, /tmp, repos outside home)
+/// can't load their local images (issue #31). The frontend resolves each
+/// referenced image to an absolute path during rendering and passes them here
+/// so we whitelist exactly those files at runtime — tighter than widening the
+/// static scope. Re-allowing an already-allowed path is a no-op.
+#[tauri::command]
+pub fn allow_assets(app: AppHandle, paths: Vec<String>) -> Result<(), String> {
+    let scope = app.asset_protocol_scope();
+    for p in &paths {
+        scope
+            .allow_file(p)
+            .map_err(|e| format!("Failed to allow asset {}: {}", p, e))?;
+    }
+    Ok(())
+}
+
 #[tauri::command]
 pub fn list_claude_plans() -> Result<Vec<PlanFile>, String> {
     let home = std::env::var("HOME").map_err(|_| "Cannot determine home directory".to_string())?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -41,6 +41,7 @@ pub fn run() {
             commands::read_markdown_file,
             commands::write_markdown_file,
             commands::resolve_path,
+            commands::allow_assets,
             commands::list_claude_plans,
             commands::list_folder_md_files,
             commands::quit_app,

--- a/src/lib/renderer/pipeline.ts
+++ b/src/lib/renderer/pipeline.ts
@@ -64,6 +64,14 @@ export interface RenderResult {
   html: string;
   frontmatter: Record<string, unknown> | null;
   wordCount: number;
+  /**
+   * Absolute on-disk paths of every local image the document references, after
+   * resolution against `baseDir`. The caller hands these to the `allow_assets`
+   * command so the webview's asset protocol will actually serve them — files
+   * outside the static `$HOME/**` scope (external drives, /tmp, repos elsewhere)
+   * are otherwise refused (issue #31).
+   */
+  assetPaths: string[];
 }
 
 let md: MarkdownIt | null = null;
@@ -206,31 +214,34 @@ export function renderFull(markdown: string, baseDir?: string): RenderResult {
     ],
   });
 
+  const assetPaths: string[] = [];
   if (baseDir) {
-    html = resolveRelativeImages(html, baseDir);
+    html = resolveRelativeImages(html, baseDir, assetPaths);
   }
 
-  return { html, frontmatter, wordCount };
+  return { html, frontmatter, wordCount, assetPaths };
 }
 
-function resolveRelativeImages(html: string, baseDir: string): string {
+function resolveRelativeImages(html: string, baseDir: string, collected: string[]): string {
   return html.replace(
     /(<img\s[^>]*?\bsrc=")(?!https?:\/\/|data:|blob:|asset:|file:)([^"]+)(")/gi,
     (_match, before, src, after) => {
       const imagePath = resolveImagePath(src, baseDir);
       try {
-        return `${before}${convertFileSrc(imagePath)}${after}`;
+        const url = `${before}${convertFileSrc(imagePath)}${after}`;
+        collected.push(imagePath);
+        return url;
       } catch {
         return `${before}${src}${after}`;
       }
     }
   ).replace(
     /(<(?:img|source)\s[^>]*?\bsrcset=")([^"]+)(")/gi,
-    (_match, before, srcset, after) => `${before}${resolveSrcset(srcset, baseDir)}${after}`
+    (_match, before, srcset, after) => `${before}${resolveSrcset(srcset, baseDir, collected)}${after}`
   );
 }
 
-function resolveSrcset(srcset: string, baseDir: string): string {
+function resolveSrcset(srcset: string, baseDir: string, collected: string[]): string {
   return srcset
     .split(",")
     .map((candidate) => {
@@ -241,7 +252,9 @@ function resolveSrcset(srcset: string, baseDir: string): string {
       if (isExternalSrc(src)) return trimmed;
 
       try {
-        const converted = convertFileSrc(resolveImagePath(src, baseDir));
+        const imagePath = resolveImagePath(src, baseDir);
+        const converted = convertFileSrc(imagePath);
+        collected.push(imagePath);
         return [converted, ...descriptor].join(" ");
       } catch {
         return trimmed;

--- a/src/lib/tauri/files.ts
+++ b/src/lib/tauri/files.ts
@@ -34,6 +34,10 @@ export async function openFile(path: string): Promise<void> {
     const content = await readMarkdownFile(absolutePath);
     const result = renderFull(content, baseDir);
 
+    // Whitelist the document's local images with the asset protocol before the
+    // HTML hits the DOM, so images outside the static $HOME scope load (#31).
+    await allowAssets(result.assetPaths);
+
     tabStore.addTab(absolutePath, fileName, content, result.html, result.frontmatter, result.wordCount);
 
     document.set({
@@ -94,6 +98,8 @@ export async function reloadCurrentFile(path: string): Promise<void> {
     const result = renderFull(content, baseDir);
     const fileName = absolutePath.split("/").pop() ?? absolutePath;
 
+    await allowAssets(result.assetPaths);
+
     tabStore.updateTabContent(absolutePath, content, result.html, result.frontmatter, result.wordCount);
 
     document.set({
@@ -119,4 +125,15 @@ export function getBaseDir(path: string): string {
 
 export async function resolvePath(path: string): Promise<string> {
   return invoke<string>("resolve_path", { path });
+}
+
+/**
+ * Whitelist resolved local image paths with the webview's asset protocol so
+ * they can be fetched regardless of the static $HOME scope (issue #31). A
+ * failure here must not block text rendering — a broken image is acceptable
+ * degradation, a blank document is not — so it's swallowed.
+ */
+export async function allowAssets(paths: string[]): Promise<void> {
+  if (paths.length === 0) return;
+  await invoke("allow_assets", { paths }).catch(() => {});
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,7 +3,7 @@
   import { document as docStore } from "$lib/stores/document";
   import { tabStore, HOME_TAB_ID, type Tab } from "$lib/stores/tabs";
   import { initRenderer, renderFull } from "$lib/renderer/pipeline";
-  import { getBaseDir, openFile, openFileDialog, saveFile } from "$lib/tauri/files";
+  import { allowAssets, getBaseDir, openFile, openFileDialog, saveFile } from "$lib/tauri/files";
   import { settings } from "$lib/stores/settings";
   import { startFileWatcher } from "$lib/tauri/watcher";
   import { themeMode, cycleTheme } from "$lib/stores/theme";
@@ -173,6 +173,10 @@
       if (activeTab.isEditing && activeTab.dirty) {
         const baseDir = getBaseDir(activeTab.filePath);
         const result = renderFull(activeTab.editContent, baseDir);
+        // Fire-and-forget: referenced images were almost always allowed at open;
+        // a brand-new external image typed mid-edit self-heals on the next
+        // render/reload. Not worth making this sync path async (#31).
+        allowAssets(result.assetPaths);
         // Update the rendered HTML in the docStore so the viewer reflects
         // the unsaved edits. We do NOT call tabStore.updateTabContent or
         // markSaved — the source on disk is unchanged, dirty stays true.
@@ -207,6 +211,7 @@
       await saveFile(tab.filePath, tab.editContent);
       const baseDir = getBaseDir(tab.filePath);
       const result = renderFull(tab.editContent, baseDir);
+      await allowAssets(result.assetPaths);
       tabStore.markSaved(tab.id);
       tabStore.updateTabContent(
         tab.filePath,


### PR DESCRIPTION
Fixes #31.

## Problem
#26 enabled the asset protocol with a static `$HOME/**` scope, so documents opened from **outside** the home folder (external drives, `/tmp`, repos elsewhere) render their local images as broken-image icons. Path resolution was already correct — only the scope was too narrow.

## Fix (runtime per-image allow)
- `renderFull()` now returns `assetPaths` — the resolved absolute path of every local image it rewrites.
- New Rust command `allow_assets(paths)` whitelists exactly those files via `asset_protocol_scope().allow_file()`. This is **tighter** than widening the static scope — the webview can fetch only the images the open document references, not the whole home folder.
- Awaited before the HTML paints in the async open/reload/save paths (so the first fetch doesn't 403); fire-and-forget in the editor live-render path (referenced images are already allowed from open).
- Static `$HOME/**` scope kept as-is for backward-compatibility; narrowing it is a separate security follow-up.

## Verified locally
- 🟢 relative + 🔵 same-dir images under `$HOME` still render (no regression)
- 🔴 absolute image in `/tmp` (outside `$HOME`) now renders
- 🟣 `../`-escape image, doc + image both outside `$HOME` — renders
- `paste://`/`url://` tabs unaffected (no baseDir → no asset paths)
- `pnpm check` clean (no new errors), `cargo check` clean

## Note on CI
macOS build may show red on the notarization step — that's an expired Apple Developer Program License Agreement (account-side), unrelated to this change. Windows + type/compile checks reflect this PR.