### PR TITLE
fix: add macOS Window menu so window-tiling shortcuts work (#34)

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,3 +31,14 @@ tauri-plugin-process = "2"
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-updater = "2"
 
+[dev-dependencies]
+# `test` enables Tauri's mock runtime (tauri::test) used by the menu test.
+tauri = { version = "2", features = ["test"] }
+
+# muda menu objects can only be created on the main thread, so this target opts
+# out of the default (threaded) libtest harness and runs on the binary's main
+# thread via `fn main()`.
+[[test]]
+name = "menu_window"
+harness = false
+

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,5 @@
 mod commands;
-mod menu;
+pub mod menu;
 mod watcher;
 
 use std::sync::Mutex;

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -1,9 +1,9 @@
 use tauri::{
-    menu::{Menu, MenuItem, PredefinedMenuItem, Submenu},
-    AppHandle,
+    menu::{Menu, MenuItem, PredefinedMenuItem, Submenu, WINDOW_SUBMENU_ID},
+    AppHandle, Runtime,
 };
 
-pub fn create_menu(app: &AppHandle) -> Result<Menu<tauri::Wry>, tauri::Error> {
+pub fn create_menu<R: Runtime>(app: &AppHandle<R>) -> Result<Menu<R>, tauri::Error> {
     // macOS app menu (app name menu with Quit, Hide, etc.)
     let app_menu = Submenu::with_items(
         app,
@@ -76,7 +76,31 @@ pub fn create_menu(app: &AppHandle) -> Result<Menu<tauri::Wry>, tauri::Error> {
         ],
     )?;
 
-    let menu = Menu::with_items(app, &[&app_menu, &file_menu, &edit_menu, &view_menu])?;
+    // Standard macOS "Window" menu. The submenu MUST use Tauri's
+    // `WINDOW_SUBMENU_ID` so that `AppHandle::set_menu` registers it as the
+    // NSApp windows menu (`set_as_windows_menu_for_nsapp`). That registration
+    // is what makes macOS inject the standard window commands — including the
+    // Sequoia "Move & Resize" window-tiling shortcuts (fn+Control+arrows) — and
+    // the live window list. Without a submenu carrying this id the tiling
+    // shortcuts (and Cmd+M minimize) never exist for the app.
+    //
+    // `close_window` is intentionally omitted: its default accelerator is
+    // Cmd+W, which the app already binds in the File menu to "Close Tab".
+    let window_menu = Submenu::with_id_and_items(
+        app,
+        WINDOW_SUBMENU_ID,
+        "Window",
+        true,
+        &[
+            &PredefinedMenuItem::minimize(app, None)?,
+            &PredefinedMenuItem::maximize(app, None)?,
+        ],
+    )?;
+
+    let menu = Menu::with_items(
+        app,
+        &[&app_menu, &file_menu, &edit_menu, &view_menu, &window_menu],
+    )?;
 
     Ok(menu)
 }

--- a/src-tauri/tests/menu_window.rs
+++ b/src-tauri/tests/menu_window.rs
@@ -1,0 +1,68 @@
+//! Integration test for the macOS window-tiling fix.
+//!
+//! macOS only injects the standard window commands — Minimize/Zoom plus the
+//! Sequoia "Move & Resize" tiling shortcuts (fn+Control+arrows) — into the
+//! submenu that `AppHandle::set_menu` registers as the NSApp windows menu, and
+//! it selects that submenu purely by id (`WINDOW_SUBMENU_ID`). If the app menu
+//! ever loses a submenu carrying this exact id, the tiling shortcuts silently
+//! break again (the original bug).
+//!
+//! muda menu objects can only be constructed on the main thread, so this target
+//! sets `harness = false` (see Cargo.toml) and runs the assertions from `main`,
+//! which executes on the process's main thread.
+
+fn main() {
+    // The build matrix is macOS + Windows. muda needs a desktop GUI stack
+    // (GTK on Linux); skip elsewhere so `cargo test` stays green off-target.
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    run();
+
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    eprintln!("skipping window-menu test on this platform");
+}
+
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+fn run() {
+    use tauri::menu::WINDOW_SUBMENU_ID;
+
+    let app = tauri::test::mock_app();
+    let menu = mdhero_lib::menu::create_menu(app.handle()).expect("menu should build");
+
+    let window_item = menu.get(WINDOW_SUBMENU_ID).unwrap_or_else(|| {
+        panic!(
+            "a submenu with WINDOW_SUBMENU_ID ({WINDOW_SUBMENU_ID:?}) must exist so \
+             AppHandle::set_menu registers it as the windows menu and macOS injects \
+             the Minimize/Zoom + Move & Resize tiling shortcuts"
+        )
+    });
+
+    let submenu = window_item
+        .as_submenu()
+        .expect("the WINDOW_SUBMENU_ID entry must be a submenu");
+
+    assert_eq!(submenu.text().unwrap(), "Window");
+    // We supply Minimize + Zoom; macOS appends Move & Resize and the live window
+    // list at runtime. Omitting close_window keeps Cmd+W bound to "Close Tab".
+    assert_eq!(
+        submenu.items().unwrap().len(),
+        2,
+        "window submenu should expose exactly Minimize and Zoom"
+    );
+
+    // The pre-existing Edit > Find item (Cmd+F) must remain intact.
+    let edit = menu
+        .items()
+        .unwrap()
+        .into_iter()
+        .find_map(|item| {
+            let submenu = item.as_submenu()?;
+            (submenu.text().ok()? == "Edit").then(|| submenu.clone())
+        })
+        .expect("Edit submenu should exist");
+    assert!(
+        edit.get("find").is_some(),
+        "Edit > Find (Cmd+F) should be preserved"
+    );
+
+    println!("ok: Window submenu present with tiling id; Edit > Find preserved");
+}


### PR DESCRIPTION
Fixes #34

## Problem
On macOS, MDHero's window-tiling keyboard shortcuts don't work: `fn`+`Control`+arrows (Sequoia tiling) and `Cmd+M` (Minimize) do nothing, and there's no **Window** menu.

## Root cause
`src-tauri/src/menu.rs` builds a fully custom menu with only **MDHero / File / Edit / View** — no Window submenu. macOS only injects the standard window commands (Minimize/Zoom + the "Move & Resize" tiling items and their shortcuts) into the submenu registered as the NSApp *windows menu*. Tauri does that registration automatically inside `AppHandle::set_menu` (`init_app_menu` → `set_as_windows_menu_for_nsapp`) for the submenu whose id is `tauri::menu::WINDOW_SUBMENU_ID`. With no such submenu, the shortcuts never exist.

## Fix
Add a standard **Window** submenu built with `WINDOW_SUBMENU_ID` (Minimize + Zoom). `set_menu` then registers it and macOS restores the tiling shortcuts, `Cmd+M`, and the live window list.

`close_window` is intentionally **omitted** so its default `Cmd+W` doesn't collide with the app's existing File → "Close Tab" (also `Cmd+W`).

`create_menu` is made generic over `Runtime` so it can be built with Tauri's mock runtime in tests.

## Testing
- **Automated:** new `src-tauri/tests/menu_window.rs` (run with `cargo test`). muda menus can only be built on the main thread, so the target uses `harness = false` and asserts from `main` that the menu contains a submenu with `WINDOW_SUBMENU_ID` titled "Window" with the expected items, and that Edit → Find is preserved.
- `cargo build` and `cargo fmt --check` pass.
- **Manual (macOS 15+):** focus MDHero, press `fn`+`Control`+`←/→/↑/↓` → window tiles; `Cmd+M` minimizes; a **Window** menu appears with Move & Resize.

## Notes
- No behavior change on the existing menus; `Cmd+W` / `Cmd+F` etc. are untouched.
