### PR TITLE
fix: make Cmd+F find work in edit (and raw) mode (#33)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
+    "test": "svelte-kit sync && vitest run",
     "tauri": "tauri"
   },
   "license": "MIT",
@@ -46,6 +47,7 @@
     "svelte-check": "^4.0.0",
     "tailwindcss": "^4.2.2",
     "typescript": "~5.6.2",
-    "vite": "^6.0.3"
+    "vite": "^6.0.3",
+    "vitest": "^2.1.9"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,9 @@ importers:
       vite:
         specifier: ^6.0.3
         version: 6.4.1(jiti@2.6.1)(lightningcss@1.32.0)
+      vitest:
+        specifier: ^2.1.9
+        version: 2.1.9(lightningcss@1.32.0)
 
 packages:
 
@@ -129,16 +132,34 @@ packages:
   '@chevrotain/utils@11.1.2':
     resolution: {integrity: sha512-4mudFAQ6H+MqBTfqLmU7G1ZwRzCLfJEooL/fsF6rCX5eePMbGhoy5n4g+G4vlh2muDcsCTJtL+uKbOzWxs5LHA==}
 
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.25.12':
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.25.12':
@@ -147,16 +168,34 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.25.12':
     resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.25.12':
     resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.25.12':
@@ -165,10 +204,22 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.25.12':
     resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.25.12':
@@ -177,10 +228,22 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.25.12':
     resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.25.12':
@@ -189,10 +252,22 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.25.12':
     resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.25.12':
@@ -201,10 +276,22 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.25.12':
     resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.25.12':
@@ -213,16 +300,34 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.25.12':
     resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.25.12':
     resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
     engines: {node: '>=18'}
     cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [linux]
 
   '@esbuild/linux-x64@0.25.12':
@@ -237,6 +342,12 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.25.12':
     resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
     engines: {node: '>=18'}
@@ -247,6 +358,12 @@ packages:
     resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.25.12':
@@ -261,11 +378,23 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.25.12':
     resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
 
   '@esbuild/win32-arm64@0.25.12':
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
@@ -273,10 +402,22 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.25.12':
     resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.25.12':
@@ -824,6 +965,35 @@ packages:
   '@upsetjs/venn.js@2.0.0':
     resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
 
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
@@ -835,6 +1005,10 @@ packages:
   aria-query@5.3.1:
     resolution: {integrity: sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==}
     engines: {node: '>= 0.4'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   autoprefixer@10.4.27:
     resolution: {integrity: sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==}
@@ -857,8 +1031,20 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   caniuse-lite@1.0.30001785:
     resolution: {integrity: sha512-blhOL/WNR+Km1RI/LCVAvA73xplXA7ZbjzI4YkMK9pa6T/P3F2GxjNpEkyw5repTw9IvkyrjyHpwjnhZ5FOvYQ==}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   chevrotain-allstar@0.3.1:
     resolution: {integrity: sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==}
@@ -1070,6 +1256,10 @@ packages:
       supports-color:
         optional: true
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
@@ -1098,6 +1288,14 @@ packages:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
+
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
     engines: {node: '>=18'}
@@ -1112,6 +1310,13 @@ packages:
 
   esrap@2.2.4:
     resolution: {integrity: sha512-suICpxAmZ9A8bzJjEl/+rLJiDKC0X4gYWUxT6URAWBLvlXmtbZd5ySMu/N2ZGEtMCAmflUDPSehrP9BQcsGcSg==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1265,6 +1470,9 @@ packages:
   lodash-es@4.18.1:
     resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -1326,8 +1534,15 @@ packages:
   path-data-parser@0.1.0:
     resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
 
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -1388,6 +1603,9 @@ packages:
   set-cookie-parser@3.1.0:
     resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
@@ -1395,6 +1613,12 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   stylis@4.3.6:
     resolution: {integrity: sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==}
@@ -1418,6 +1642,12 @@ packages:
     resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
     engines: {node: '>=6'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyexec@1.0.4:
     resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
     engines: {node: '>=18'}
@@ -1425,6 +1655,18 @@ packages:
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
 
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
@@ -1457,6 +1699,42 @@ packages:
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
     hasBin: true
+
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
 
   vite@6.4.1:
     resolution: {integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==}
@@ -1506,6 +1784,31 @@ packages:
       vite:
         optional: true
 
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vscode-jsonrpc@8.2.0:
     resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
     engines: {node: '>=14.0.0'}
@@ -1525,6 +1828,11 @@ packages:
 
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
 
   zimmerframe@1.1.4:
     resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
@@ -1555,52 +1863,103 @@ snapshots:
 
   '@chevrotain/utils@11.1.2': {}
 
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
   '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
     optional: true
 
   '@esbuild/android-arm64@0.25.12':
     optional: true
 
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
   '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
     optional: true
 
   '@esbuild/android-x64@0.25.12':
     optional: true
 
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
   '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
     optional: true
 
   '@esbuild/darwin-x64@0.25.12':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
   '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
     optional: true
 
   '@esbuild/linux-arm@0.25.12':
     optional: true
 
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
   '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
     optional: true
 
   '@esbuild/linux-loong64@0.25.12':
     optional: true
 
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
   '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
   '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
   '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
     optional: true
 
   '@esbuild/linux-x64@0.25.12':
@@ -1609,10 +1968,16 @@ snapshots:
   '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
   '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.12':
@@ -1621,13 +1986,25 @@ snapshots:
   '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
   '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
     optional: true
 
   '@esbuild/win32-arm64@0.25.12':
     optional: true
 
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
   '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
     optional: true
 
   '@esbuild/win32-x64@0.25.12':
@@ -2090,11 +2467,53 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.21(lightningcss@1.32.0))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(lightningcss@1.32.0)
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.21
+      pathe: 1.1.2
+
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
+
   acorn@8.16.0: {}
 
   argparse@2.0.1: {}
 
   aria-query@5.3.1: {}
+
+  assertion-error@2.0.1: {}
 
   autoprefixer@10.4.27(postcss@8.5.8):
     dependencies:
@@ -2117,7 +2536,19 @@ snapshots:
       node-releases: 2.0.37
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
+  cac@6.7.14: {}
+
   caniuse-lite@1.0.30001785: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  check-error@2.1.3: {}
 
   chevrotain-allstar@0.3.1(chevrotain@11.1.2):
     dependencies:
@@ -2347,6 +2778,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  deep-eql@5.0.2: {}
+
   deepmerge@4.3.1: {}
 
   delaunator@5.1.0:
@@ -2369,6 +2802,34 @@ snapshots:
       tapable: 2.3.2
 
   entities@4.5.0: {}
+
+  es-module-lexer@1.7.0: {}
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -2407,6 +2868,12 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
       '@typescript-eslint/types': 8.58.0
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  expect-type@1.4.0: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -2516,6 +2983,8 @@ snapshots:
 
   lodash-es@4.18.1: {}
 
+  loupe@3.2.1: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -2589,7 +3058,11 @@ snapshots:
 
   path-data-parser@0.1.0: {}
 
+  pathe@1.1.2: {}
+
   pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
 
   picocolors@1.1.1: {}
 
@@ -2675,6 +3148,8 @@ snapshots:
 
   set-cookie-parser@3.1.0: {}
 
+  siginfo@2.0.0: {}
+
   sirv@3.0.2:
     dependencies:
       '@polka/url': 1.0.0-next.29
@@ -2682,6 +3157,10 @@ snapshots:
       totalist: 3.0.1
 
   source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
 
   stylis@4.3.6: {}
 
@@ -2720,12 +3199,22 @@ snapshots:
 
   tapable@2.3.2: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
   tinyexec@1.0.4: {}
 
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
+  tinyspy@3.0.2: {}
 
   totalist@3.0.1: {}
 
@@ -2747,6 +3236,33 @@ snapshots:
 
   uuid@11.1.0: {}
 
+  vite-node@2.1.9(lightningcss@1.32.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(lightningcss@1.32.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite@5.4.21(lightningcss@1.32.0):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.8
+      rollup: 4.60.1
+    optionalDependencies:
+      fsevents: 2.3.3
+      lightningcss: 1.32.0
+
   vite@6.4.1(jiti@2.6.1)(lightningcss@1.32.0):
     dependencies:
       esbuild: 0.25.12
@@ -2764,6 +3280,39 @@ snapshots:
     optionalDependencies:
       vite: 6.4.1(jiti@2.6.1)(lightningcss@1.32.0)
 
+  vitest@2.1.9(lightningcss@1.32.0):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(lightningcss@1.32.0))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(lightningcss@1.32.0)
+      vite-node: 2.1.9(lightningcss@1.32.0)
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vscode-jsonrpc@8.2.0: {}
 
   vscode-languageserver-protocol@3.17.5:
@@ -2780,5 +3329,10 @@ snapshots:
       vscode-languageserver-protocol: 3.17.5
 
   vscode-uri@3.1.0: {}
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   zimmerframe@1.1.4: {}

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
-  import { onMount, tick } from "svelte";
+  import { onMount, onDestroy, tick } from "svelte";
+  import { searchQuery, searchActiveIndex, searchTotal } from "$lib/stores/search";
+  import { findMatches, buildHighlightHtml } from "$lib/utils/text-search";
 
   let {
     value,
@@ -16,6 +18,7 @@
   } = $props();
 
   let textareaEl: HTMLTextAreaElement | undefined = $state();
+  let backdropEl: HTMLDivElement | undefined = $state();
 
   // Local mirror so cursor doesn't jump on parent state updates
   // svelte-ignore state_referenced_locally
@@ -29,6 +32,45 @@
     }
   });
 
+  // --- Find-in-editor highlight backdrop --------------------------------------
+  // mark.js can't highlight a <textarea> (its contents aren't markable DOM text),
+  // so the find overlay's edit-mode path mirrors the text into an aria-hidden
+  // backdrop sitting exactly behind the transparent textarea and paints <mark>s
+  // there. The textarea's opaque text renders on top of the (transparent)
+  // backdrop text, so only the match backgrounds show through.
+  const matches = $derived(findMatches(localValue, $searchQuery));
+  const highlightHtml = $derived(
+    $searchQuery ? buildHighlightHtml(localValue, matches, $searchActiveIndex) : ""
+  );
+
+  // Publish the match count so the overlay's "n/total" counter and its
+  // Enter / prev / next navigation work while editing.
+  $effect(() => {
+    searchTotal.set($searchQuery ? matches.length : 0);
+  });
+
+  function syncBackdropScroll() {
+    if (backdropEl && textareaEl) {
+      backdropEl.scrollTop = textareaEl.scrollTop;
+      backdropEl.scrollLeft = textareaEl.scrollLeft;
+    }
+  }
+
+  // Scroll the active match into view whenever it changes (next/prev/new search).
+  $effect(() => {
+    const idx = $searchActiveIndex;
+    if (!$searchQuery || matches.length === 0) return;
+    // Defer until the backdrop has rendered the new active <mark>.
+    requestAnimationFrame(() => {
+      const ta = textareaEl;
+      const mark = backdropEl?.querySelector<HTMLElement>(`mark[data-match-index="${idx}"]`);
+      if (!ta || !mark) return;
+      const target = mark.offsetTop - ta.clientHeight / 2;
+      ta.scrollTop = Math.max(0, target);
+      syncBackdropScroll();
+    });
+  });
+
   onMount(() => {
     tick().then(() => {
       try {
@@ -39,8 +81,14 @@
     });
   });
 
+  onDestroy(() => {
+    // Don't leave a stale match count behind when leaving edit mode.
+    searchTotal.set(0);
+  });
+
   function handleInput() {
     onChange(localValue);
+    syncBackdropScroll();
   }
 
   function handleKeydown(e: KeyboardEvent) {
@@ -63,17 +111,28 @@
 </script>
 
 <div class="editor-wrap">
-  <textarea
-    bind:this={textareaEl}
-    bind:value={localValue}
-    oninput={handleInput}
-    onkeydown={handleKeydown}
-    class="editor"
-    style="font-size: {fontSize}px; line-height: {lineHeight}; max-width: {maxWidth};"
-    spellcheck="false"
-    autocomplete="off"
-    autocapitalize="off"
-  ></textarea>
+  <div class="editor-stack" style="max-width: {maxWidth};">
+    <!-- Highlight layer: mirrors the textarea text so search matches can be
+         painted behind the transparent textarea. -->
+    <div
+      bind:this={backdropEl}
+      class="editor-backdrop"
+      aria-hidden="true"
+      style="font-size: {fontSize}px; line-height: {lineHeight};"
+    >{@html highlightHtml}</div>
+    <textarea
+      bind:this={textareaEl}
+      bind:value={localValue}
+      oninput={handleInput}
+      onkeydown={handleKeydown}
+      onscroll={syncBackdropScroll}
+      class="editor"
+      style="font-size: {fontSize}px; line-height: {lineHeight};"
+      spellcheck="false"
+      autocomplete="off"
+      autocapitalize="off"
+    ></textarea>
+  </div>
 </div>
 
 <style>
@@ -96,21 +155,40 @@
     background: #161618;
   }
 
-  .editor {
+  .editor-stack {
+    position: relative;
     flex: 1;
     width: 100%;
     height: 100%;
+  }
+
+  /* The textarea and the highlight backdrop MUST share identical text metrics
+     and box sizing so their wrapped lines line up exactly. */
+  .editor,
+  .editor-backdrop {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    margin: 0;
     padding: 32px;
-    background: transparent;
     border: none;
-    outline: none;
-    resize: none;
-    color: #1c1c1e;
     font-family: "SF Mono", "JetBrains Mono", "Fira Code", Menlo, monospace;
     tab-size: 2;
     -moz-tab-size: 2;
-    word-wrap: break-word;
     white-space: pre-wrap;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+    box-sizing: border-box;
+  }
+
+  .editor {
+    background: transparent;
+    outline: none;
+    resize: none;
+    color: #1c1c1e;
+    overflow: auto;
+    z-index: 1;
   }
 
   :global(html.dark) .editor {
@@ -119,5 +197,34 @@
 
   .editor::placeholder {
     color: #aeaeb2;
+  }
+
+  .editor-backdrop {
+    overflow: hidden;
+    color: transparent;
+    pointer-events: none;
+    user-select: none;
+    z-index: 0;
+  }
+
+  /* In the backdrop only the <mark> backgrounds should be visible; the real,
+     opaque textarea text sits on top, so keep the mark text transparent. */
+  .editor-backdrop :global(mark.mdv-search-highlight) {
+    color: transparent;
+    background-color: #fde68a;
+    border-radius: 2px;
+  }
+
+  :global(html.dark) .editor-backdrop :global(mark.mdv-search-highlight) {
+    background-color: #854d0e;
+  }
+
+  .editor-backdrop :global(mark.mdv-search-active) {
+    color: transparent !important;
+    background-color: #f97316 !important;
+  }
+
+  :global(html.dark) .editor-backdrop :global(mark.mdv-search-active) {
+    background-color: #ea580c !important;
   }
 </style>

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -180,6 +180,16 @@
     word-wrap: break-word;
     overflow-wrap: break-word;
     box-sizing: border-box;
+    /* Both layers MUST reserve an identical scrollbar gutter, otherwise their
+       lines wrap at different widths. The textarea is the scroll container, so
+       when its vertical scrollbar appears it shrinks the text width by the
+       scrollbar's size; the backdrop (no scrollbar) would keep the full width,
+       so its lines wrap later and the highlights drift up by one row per
+       differently-wrapped line, accumulating down the document. Forcing
+       `overflow-y: scroll` on BOTH always reserves the same gutter (zero with
+       macOS overlay scrollbars, ~15px with classic ones), keeping them in sync. */
+    overflow-x: hidden;
+    overflow-y: scroll;
   }
 
   .editor {
@@ -187,7 +197,6 @@
     outline: none;
     resize: none;
     color: #1c1c1e;
-    overflow: auto;
     z-index: 1;
   }
 
@@ -200,7 +209,6 @@
   }
 
   .editor-backdrop {
-    overflow: hidden;
     color: transparent;
     pointer-events: none;
     user-select: none;

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -39,8 +39,14 @@
   // there. The textarea's opaque text renders on top of the (transparent)
   // backdrop text, so only the match backgrounds show through.
   const matches = $derived(findMatches(localValue, $searchQuery));
+  // Mirror the text with an appended trailing newline so the pre-wrap backdrop
+  // reserves the same final line a <textarea> always keeps. Without it the
+  // backdrop is ~1 line shorter, so near the document bottom its scrollTop
+  // clamps to a smaller max and the highlights drift ~1 line below the text.
+  // `matches` are computed on the un-suffixed `localValue`, so the extra newline
+  // sits past every match and can't shift any offset.
   const highlightHtml = $derived(
-    $searchQuery ? buildHighlightHtml(localValue, matches, $searchActiveIndex) : ""
+    $searchQuery ? buildHighlightHtml(localValue + "\n", matches, $searchActiveIndex) : ""
   );
 
   // Publish the match count so the overlay's "n/total" counter and its

--- a/src/lib/components/SearchOverlay.svelte
+++ b/src/lib/components/SearchOverlay.svelte
@@ -1,49 +1,67 @@
 <script lang="ts">
-  import { onMount } from "svelte";
   import Mark from "mark.js";
+  import {
+    searchQuery,
+    searchActiveIndex,
+    searchTotal,
+    resetSearch,
+  } from "$lib/stores/search";
+  import { cycleIndex } from "$lib/utils/text-search";
 
   let { visible = $bindable(false) }: { visible: boolean } = $props();
 
-  let query = $state("");
-  let currentMatch = $state(0);
-  let totalMatches = $state(0);
   let inputEl: HTMLInputElement | undefined = $state();
   let markInstance: Mark | null = null;
+  let markTarget: HTMLElement | null = null;
 
-  function getArticle(): HTMLElement | null {
-    return document.querySelector("article.prose");
+  /**
+   * The DOM element to highlight in non-edit modes: the rendered Markdown
+   * (`article.prose`) or the raw-source `<pre>`. In edit mode neither exists —
+   * the document is a `<textarea>` whose contents aren't markable DOM text, so
+   * the Editor component renders its own highlight backdrop instead.
+   */
+  function getViewTarget(): HTMLElement | null {
+    return document.querySelector<HTMLElement>("article.prose, pre.raw-source");
+  }
+
+  function clearMarks() {
+    markInstance?.unmark();
+    markInstance = null;
+    markTarget = null;
   }
 
   function doSearch() {
-    const article = getArticle();
-    if (!article) return;
+    const target = getViewTarget();
+    if (!target) return; // edit mode: the Editor backdrop owns highlighting
 
-    if (!markInstance) {
-      markInstance = new Mark(article);
+    if (markTarget !== target) {
+      markInstance?.unmark();
+      markInstance = new Mark(target);
+      markTarget = target;
     }
+    const instance = markInstance!;
 
-    markInstance.unmark({
+    instance.unmark({
       done: () => {
-        if (!query.trim()) {
-          totalMatches = 0;
-          currentMatch = 0;
+        if (!$searchQuery.trim()) {
+          searchTotal.set(0);
+          searchActiveIndex.set(0);
           return;
         }
-
-        markInstance!.mark(query, {
+        instance.mark($searchQuery, {
           separateWordSearch: false,
           className: "mdv-search-highlight",
           done: (count) => {
-            totalMatches = count;
-            currentMatch = count > 0 ? 1 : 0;
-            if (count > 0) scrollToMatch(0);
+            searchTotal.set(count);
+            searchActiveIndex.set(0);
+            if (count > 0) scrollToViewMatch(0);
           },
         });
       },
     });
   }
 
-  function scrollToMatch(index: number) {
+  function scrollToViewMatch(index: number) {
     const marks = document.querySelectorAll("mark.mdv-search-highlight");
     if (marks.length === 0) return;
     marks.forEach((m) => m.classList.remove("mdv-search-active"));
@@ -55,24 +73,19 @@
   }
 
   function nextMatch() {
-    if (totalMatches === 0) return;
-    currentMatch = (currentMatch % totalMatches) + 1;
-    scrollToMatch(currentMatch - 1);
+    if ($searchTotal === 0) return;
+    searchActiveIndex.set(cycleIndex($searchActiveIndex, $searchTotal, 1));
   }
 
   function prevMatch() {
-    if (totalMatches === 0) return;
-    currentMatch = currentMatch <= 1 ? totalMatches : currentMatch - 1;
-    scrollToMatch(currentMatch - 1);
+    if ($searchTotal === 0) return;
+    searchActiveIndex.set(cycleIndex($searchActiveIndex, $searchTotal, -1));
   }
 
   function close() {
     visible = false;
-    query = "";
-    totalMatches = 0;
-    currentMatch = 0;
-    markInstance?.unmark();
-    markInstance = null;
+    clearMarks();
+    resetSearch();
   }
 
   function handleKeydown(e: KeyboardEvent) {
@@ -80,6 +93,7 @@
       e.stopPropagation();
       close();
     } else if (e.key === "Enter") {
+      e.preventDefault();
       if (e.shiftKey) {
         prevMatch();
       } else {
@@ -88,18 +102,33 @@
     }
   }
 
+  // Focus the input when shown; clear marks + reset state when hidden (covers
+  // close button, Esc, the Find menu toggle, and view-mode switches).
   $effect(() => {
-    if (visible && inputEl) {
-      inputEl.focus();
-      inputEl.select();
+    if (visible) {
+      inputEl?.focus();
+      inputEl?.select();
+    } else {
+      clearMarks();
+      resetSearch();
     }
   });
 
+  // Reset to the first match and re-run view-mode highlighting whenever the
+  // query changes while visible. Edit mode is handled reactively by the Editor
+  // backdrop, which reads the same query/active-index store.
   $effect(() => {
-    query;
-    if (visible) {
-      doSearch();
-    }
+    $searchQuery; // track
+    if (!visible) return;
+    searchActiveIndex.set(0);
+    doSearch();
+  });
+
+  // Move the highlighted/scrolled match when the active index changes (view
+  // mode only; the Editor handles scrolling its own active match).
+  $effect(() => {
+    const idx = $searchActiveIndex;
+    if (visible && getViewTarget()) scrollToViewMatch(idx);
   });
 </script>
 
@@ -112,25 +141,25 @@
 
     <input
       bind:this={inputEl}
-      bind:value={query}
+      bind:value={$searchQuery}
       type="text"
       placeholder="Find in document..."
       class="search-input"
     />
 
     <span class="search-count">
-      {#if totalMatches > 0}
-        {currentMatch}/{totalMatches}
-      {:else if query.trim()}
+      {#if $searchTotal > 0}
+        {$searchActiveIndex + 1}/{$searchTotal}
+      {:else if $searchQuery.trim()}
         0
       {/if}
     </span>
 
     <div class="search-nav">
-      <button onclick={prevMatch} disabled={totalMatches === 0} class="search-nav-btn" title="Previous (Shift+Enter)">
+      <button onclick={prevMatch} disabled={$searchTotal === 0} class="search-nav-btn" title="Previous (Shift+Enter)">
         <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><polyline points="2,8 6,4 10,8"/></svg>
       </button>
-      <button onclick={nextMatch} disabled={totalMatches === 0} class="search-nav-btn" title="Next (Enter)">
+      <button onclick={nextMatch} disabled={$searchTotal === 0} class="search-nav-btn" title="Next (Enter)">
         <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><polyline points="2,4 6,8 10,4"/></svg>
       </button>
     </div>

--- a/src/lib/stores/search.ts
+++ b/src/lib/stores/search.ts
@@ -1,0 +1,24 @@
+import { writable } from "svelte/store";
+
+// Shared find-in-document state.
+//
+// The find overlay (SearchOverlay) renders the controls and owns the rendered
+// (viewer/raw) highlighting via mark.js, while the Editor renders its own
+// highlight backdrop for the <textarea>. Both read this shared state so a single
+// query/active-match drives whichever target is currently on screen.
+
+/** Current find query. An empty string means there is no active search. */
+export const searchQuery = writable("");
+
+/** 0-based index of the currently focused match. */
+export const searchActiveIndex = writable(0);
+
+/** Total number of matches in the active target (viewer, raw, or editor). */
+export const searchTotal = writable(0);
+
+/** Clear all find state — called whenever the overlay is hidden. */
+export function resetSearch(): void {
+  searchQuery.set("");
+  searchActiveIndex.set(0);
+  searchTotal.set(0);
+}

--- a/src/lib/utils/text-search.ts
+++ b/src/lib/utils/text-search.ts
@@ -1,0 +1,86 @@
+// Plain-text search helpers shared by the in-document find overlay.
+//
+// The rendered (view) mode highlights matches with mark.js against the DOM, but
+// in edit mode the document is a <textarea> whose contents are not in the DOM as
+// markable text nodes. These pure helpers power the editor find path (counting,
+// cycling and backdrop highlighting) and are unit tested in isolation.
+
+export interface Match {
+  /** Inclusive start offset into the source text. */
+  start: number;
+  /** Exclusive end offset into the source text. */
+  end: number;
+}
+
+/**
+ * Find every non-overlapping, case-insensitive occurrence of `query` in `text`.
+ *
+ * The match is literal — `query` is never treated as a regular expression — so
+ * special characters such as `.` `*` `(` are matched verbatim. Returns an empty
+ * array for an empty/whitespace-free-but-empty query.
+ */
+export function findMatches(text: string, query: string): Match[] {
+  const matches: Match[] = [];
+  if (!text || !query) return matches;
+
+  const haystack = text.toLowerCase();
+  const needle = query.toLowerCase();
+  const len = needle.length;
+  if (len === 0) return matches;
+
+  let from = 0;
+  while (from <= haystack.length - len) {
+    const idx = haystack.indexOf(needle, from);
+    if (idx === -1) break;
+    matches.push({ start: idx, end: idx + len });
+    from = idx + len; // non-overlapping
+  }
+  return matches;
+}
+
+/**
+ * Move an active match index by `direction` (+1 next, -1 previous), wrapping
+ * around the ends. Returns 0 when there are no matches.
+ */
+export function cycleIndex(current: number, total: number, direction: 1 | -1): number {
+  if (total <= 0) return 0;
+  return (current + direction + total) % total;
+}
+
+const HTML_ESCAPES: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+};
+
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>]/g, (ch) => HTML_ESCAPES[ch]);
+}
+
+/**
+ * Build the HTML for the editor highlight backdrop: the source text with each
+ * match wrapped in a `<mark>`. The match at `activeIndex` additionally gets the
+ * `mdv-search-active` class so the focused hit can be styled/scrolled to.
+ *
+ * The output is rendered behind a transparent <textarea> whose `white-space` is
+ * `pre-wrap`, so newlines and spaces are preserved without extra markup.
+ */
+export function buildHighlightHtml(text: string, matches: Match[], activeIndex: number): string {
+  if (matches.length === 0) return escapeHtml(text);
+
+  let html = "";
+  let cursor = 0;
+  for (let i = 0; i < matches.length; i++) {
+    const { start, end } = matches[i];
+    if (start < cursor) continue; // defensive: skip overlaps
+    html += escapeHtml(text.slice(cursor, start));
+    const className =
+      i === activeIndex ? "mdv-search-highlight mdv-search-active" : "mdv-search-highlight";
+    html += `<mark class="${className}" data-match-index="${i}">`;
+    html += escapeHtml(text.slice(start, end));
+    html += "</mark>";
+    cursor = end;
+  }
+  html += escapeHtml(text.slice(cursor));
+  return html;
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -172,6 +172,11 @@
     if (!activeTab || target === currentMode) return;
     if (target === "editor" && !canEditActive) return;
 
+    // Close the find overlay on any mode change so a search started against one
+    // target (viewer/raw/editor) can't leave a stale match count or highlights
+    // behind when the on-screen target changes.
+    searchVisible = false;
+
     const line = getCurrentSourceLine(currentMode);
 
     // Apply state changes for the target mode

--- a/tests/unit/text-search.test.ts
+++ b/tests/unit/text-search.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest";
+import { findMatches, cycleIndex, buildHighlightHtml } from "../../src/lib/utils/text-search";
+
+describe("findMatches", () => {
+  it("returns no matches for an empty query", () => {
+    expect(findMatches("hello world", "")).toEqual([]);
+  });
+
+  it("returns no matches for empty text", () => {
+    expect(findMatches("", "x")).toEqual([]);
+  });
+
+  it("finds a single match with correct offsets", () => {
+    expect(findMatches("hello world", "world")).toEqual([{ start: 6, end: 11 }]);
+  });
+
+  it("finds multiple non-overlapping matches", () => {
+    // "aa" in "aaaa" → positions 0-2 and 2-4 (non-overlapping)
+    expect(findMatches("aaaa", "aa")).toEqual([
+      { start: 0, end: 2 },
+      { start: 2, end: 4 },
+    ]);
+  });
+
+  it("is case-insensitive", () => {
+    expect(findMatches("Markdown MARKDOWN markdown", "markdown")).toEqual([
+      { start: 0, end: 8 },
+      { start: 9, end: 17 },
+      { start: 18, end: 26 },
+    ]);
+  });
+
+  it("treats the query literally, not as a regex", () => {
+    // The '.' must match a literal dot, not any character.
+    const text = "a.b axb a.b";
+    expect(findMatches(text, "a.b")).toEqual([
+      { start: 0, end: 3 },
+      { start: 8, end: 11 },
+    ]);
+  });
+
+  it("matches special regex characters verbatim", () => {
+    expect(findMatches("cost is $5 (approx)", "(approx)")).toEqual([{ start: 11, end: 19 }]);
+  });
+
+  it("handles matches across newlines in the source text", () => {
+    const text = "line one\nTODO: x\nline three\nTODO: y";
+    expect(findMatches(text, "TODO")).toEqual([
+      { start: 9, end: 13 },
+      { start: 28, end: 32 },
+    ]);
+  });
+
+  it("returns an empty array when there is no match", () => {
+    expect(findMatches("hello", "zzz")).toEqual([]);
+  });
+});
+
+describe("cycleIndex", () => {
+  it("returns 0 when there are no matches", () => {
+    expect(cycleIndex(0, 0, 1)).toBe(0);
+    expect(cycleIndex(5, 0, -1)).toBe(0);
+  });
+
+  it("advances to the next index", () => {
+    expect(cycleIndex(0, 3, 1)).toBe(1);
+    expect(cycleIndex(1, 3, 1)).toBe(2);
+  });
+
+  it("wraps forward from the last to the first match", () => {
+    expect(cycleIndex(2, 3, 1)).toBe(0);
+  });
+
+  it("moves to the previous index", () => {
+    expect(cycleIndex(2, 3, -1)).toBe(1);
+  });
+
+  it("wraps backward from the first to the last match", () => {
+    expect(cycleIndex(0, 3, -1)).toBe(2);
+  });
+});
+
+describe("buildHighlightHtml", () => {
+  it("escapes HTML when there are no matches", () => {
+    expect(buildHighlightHtml("<b> & </b>", [], 0)).toBe("&lt;b&gt; &amp; &lt;/b&gt;");
+  });
+
+  it("wraps matches in <mark> and marks the active one", () => {
+    const text = "foo bar foo";
+    const matches = findMatches(text, "foo");
+    const html = buildHighlightHtml(text, matches, 1);
+    expect(html).toBe(
+      '<mark class="mdv-search-highlight" data-match-index="0">foo</mark>' +
+        " bar " +
+        '<mark class="mdv-search-highlight mdv-search-active" data-match-index="1">foo</mark>'
+    );
+  });
+
+  it("escapes match text and surrounding text", () => {
+    const text = "a <x> a";
+    const matches = findMatches(text, "<x>");
+    const html = buildHighlightHtml(text, matches, 0);
+    expect(html).toBe(
+      'a <mark class="mdv-search-highlight mdv-search-active" data-match-index="0">&lt;x&gt;</mark> a'
+    );
+  });
+
+  it("preserves newlines so pre-wrap rendering stays aligned", () => {
+    const text = "x\nTODO\ny";
+    const matches = findMatches(text, "TODO");
+    const html = buildHighlightHtml(text, matches, 0);
+    expect(html).toBe(
+      'x\n<mark class="mdv-search-highlight mdv-search-active" data-match-index="0">TODO</mark>\ny'
+    );
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+// Standalone Vitest config (kept separate from vite.config.js so unit tests run
+// without the SvelteKit plugin / SSR machinery). Targets the pure helpers under
+// tests/unit.
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["tests/unit/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
Fixes #33

## Problem
**Cmd+F** find only works in the rendered (viewer) mode. In **edit mode** the find bar opens but highlights/finds nothing.

## Root cause
`SearchOverlay.svelte` highlighted only `article.prose` (the rendered Markdown) with mark.js. In edit mode the document is an `Editor.svelte` `<textarea>` (and in raw mode a `<pre class="raw-source">`), so `article.prose` doesn't exist. A `<textarea>`'s contents also aren't markable DOM text, so mark.js can't be pointed at it directly.

## Fix
- **`src/lib/utils/text-search.ts`** — pure helpers: `findMatches` (literal, case-insensitive, non-overlapping), `cycleIndex` (wrap-around next/prev), `buildHighlightHtml` (escaped text + `<mark>` markup with an active match).
- **`src/lib/stores/search.ts`** — shared `searchQuery` / `searchActiveIndex` / `searchTotal` so the overlay controls and the editor highlighting stay in sync.
- **`Editor.svelte`** — render an `aria-hidden` highlight **backdrop** behind the transparent `<textarea>` and paint matches there; scroll the active match into view. No focus stealing, and all matches are highlighted (consistent with the viewer).
- **`SearchOverlay.svelte`** — drive state from the store; target `article.prose` **or** `pre.raw-source` (so raw mode is fixed too); reset state when hidden.
- **`+page.svelte`** — close the find overlay on any view-mode switch to avoid stale cross-mode highlights.

## Testing
- **Automated:** adds **Vitest** with **18 unit tests** for the matching utility — `pnpm test` (case-insensitivity, literal/regex-safety, multi/overlapping matches, newlines, wrap-around navigation, HTML escaping + active-match markup).
- `pnpm check` passes (no new svelte-check errors; the 3 pre-existing errors in `pipeline.ts`/`Toolbar.svelte` are unrelated).
- `pnpm build` passes.
- **Manual:** enter edit mode, `Cmd+F`, type a term → matches highlight, `n/total` updates, Enter / Shift+Enter / ▲▼ cycle and scroll. Same in raw mode and the (unchanged) viewer.

## Notes
- Viewer highlighting still uses mark.js — that path is unchanged, only the target selector was broadened.
- `package.json` gains a `test` script (`svelte-kit sync && vitest run`) and a `vitest` devDependency.
