### PR TITLE
feat: open local file links in-app, OS opener for others (#30)

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -6,6 +6,10 @@
   "permissions": [
     "core:default",
     "opener:default",
+    {
+      "identifier": "opener:allow-open-path",
+      "allow": [{ "path": "**" }]
+    },
     "dialog:default",
     "cli:default",
     "core:event:default",

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -67,6 +67,14 @@ pub fn resolve_path(path: String) -> Result<String, String> {
         .ok_or_else(|| format!("Path is not valid UTF-8: {}", path))
 }
 
+/// Whether a path exists on disk. Used by the local-file-link handler (#30)
+/// to surface a graceful "file not found" toast before attempting to open,
+/// instead of silently no-opping or replacing the current document.
+#[tauri::command]
+pub fn path_exists(path: String) -> bool {
+    Path::new(&path).exists()
+}
+
 /// Allow the webview's asset protocol to serve specific image files.
 ///
 /// The static `assetProtocol.scope` in tauri.conf.json only covers `$HOME`, so

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -41,6 +41,7 @@ pub fn run() {
             commands::read_markdown_file,
             commands::write_markdown_file,
             commands::resolve_path,
+            commands::path_exists,
             commands::allow_assets,
             commands::list_claude_plans,
             commands::list_folder_md_files,

--- a/src/lib/components/MarkdownRenderer.svelte
+++ b/src/lib/components/MarkdownRenderer.svelte
@@ -10,15 +10,34 @@
   let {
     html = "",
     onImageClick = (_src: string, _all: string[], _idx: number) => {},
+    onLocalLink,
   }: {
     html: string;
     onImageClick?: (src: string, allImages: string[], index: number) => void;
+    /**
+     * Called when a link to a local file (relative or absolute path, no URL
+     * scheme) is clicked. The parent resolves it against the current document
+     * and opens it in-app or via the OS (issue #30). When omitted, such links
+     * fall back to the external opener.
+     */
+    onLocalLink?: (href: string) => void;
   } = $props();
+
+  /** True for hrefs that are real URLs (browser/mail/etc.), not filesystem paths. */
+  function isUrlHref(href: string): boolean {
+    // Any explicit scheme except file: — http, https, mailto, tel, data, blob…
+    // `file:` is a local file (handled by onLocalLink), so it's excluded here.
+    return /^(?!file:)[a-z][a-z0-9+.-]*:/i.test(href) || href.startsWith("//");
+  }
 
   let articleEl: HTMLElement | undefined = $state();
   let observer: IntersectionObserver | undefined;
   let lastMermaidTheme = "";
   let tooltipEl: HTMLDivElement | undefined;
+
+  function hideTooltip() {
+    if (tooltipEl) tooltipEl.style.display = "none";
+  }
 
   function initMermaid() {
     const isDark = document.documentElement.classList.contains("dark");
@@ -124,12 +143,19 @@
     return () => {
       articleEl?.removeEventListener("contextmenu", handleContextMenu);
       observer?.disconnect();
+      // Remove the body-level tooltip so it can't outlive the component.
+      tooltipEl?.remove();
+      tooltipEl = undefined;
     };
   });
 
   $effect(() => {
     // Re-run when html changes
     html;
+
+    // A re-render (e.g. opening a linked file in a new tab) replaces the
+    // article, so a hover's mouseleave may never fire — clear any stuck tooltip.
+    hideTooltip();
 
     tick().then(() => {
       if (!articleEl) return;
@@ -151,7 +177,7 @@
       addLinkTooltips();
 
       // Open external links in system browser
-      addExternalLinkHandlers();
+      addLinkHandlers();
 
       // Render Mermaid diagrams
       renderMermaidBlocks();
@@ -177,7 +203,11 @@
     if (!articleEl) return;
 
     // Create tooltip element once
-    if (!tooltipEl) {
+    // Sweep any orphaned tooltips left by dev HMR reloads so they can't pile up.
+    document.querySelectorAll(".link-tooltip").forEach((el) => {
+      if (el !== tooltipEl) el.remove();
+    });
+    if (!tooltipEl || !tooltipEl.isConnected) {
       tooltipEl = document.createElement("div");
       tooltipEl.className = "link-tooltip";
       document.body.appendChild(tooltipEl);
@@ -198,23 +228,29 @@
         tooltipEl!.style.top = `${rect.bottom + 4}px`;
       });
 
-      link.addEventListener("mouseleave", () => {
-        tooltipEl!.style.display = "none";
-      });
+      link.addEventListener("mouseleave", hideTooltip);
     });
   }
 
-  function addExternalLinkHandlers() {
+  function addLinkHandlers() {
     if (!articleEl) return;
     const links = articleEl.querySelectorAll("a[href]");
     links.forEach((link) => {
-      if ((link as HTMLElement).dataset.externalBound) return;
+      if ((link as HTMLElement).dataset.linkBound) return;
       const href = link.getAttribute("href") ?? "";
-      // Skip anchor links (in-page navigation)
+      // Skip anchor links (in-page navigation handled by the browser default).
       if (!href || href.startsWith("#")) return;
-      (link as HTMLElement).dataset.externalBound = "true";
+      (link as HTMLElement).dataset.linkBound = "true";
       link.addEventListener("click", async (e) => {
         e.preventDefault();
+        hideTooltip();
+        // Local file path (no URL scheme, or a file: URL) → let the parent
+        // resolve it against the current document and open it (#30).
+        if (onLocalLink && !isUrlHref(href)) {
+          onLocalLink(href);
+          return;
+        }
+        // Real URL → external opener (browser, mail client, …).
         try {
           const { openUrl } = await import("@tauri-apps/plugin-opener");
           await openUrl(href);

--- a/src/lib/components/Toast.svelte
+++ b/src/lib/components/Toast.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+  import { toasts } from "$lib/stores/toast";
+</script>
+
+{#if $toasts.length > 0}
+  <div class="toast-stack">
+    {#each $toasts as toast (toast.id)}
+      <div class="toast">
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <circle cx="8" cy="8" r="6.5" />
+          <path d="M8 5v3.5M8 11h.01" />
+        </svg>
+        <span class="toast-text">{toast.message}</span>
+      </div>
+    {/each}
+  </div>
+{/if}
+
+<style>
+  .toast-stack {
+    position: fixed;
+    bottom: 96px;
+    right: 16px;
+    z-index: 101;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    align-items: flex-end;
+  }
+
+  .toast {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    max-width: 360px;
+    padding: 10px 14px;
+    background: white;
+    border: 1px solid #e5e5ea;
+    border-radius: 10px;
+    box-shadow: 0 4px 20px rgba(0,0,0,0.08), 0 1px 3px rgba(0,0,0,0.06);
+    font-size: 12px;
+    color: #1c1c1e;
+    animation: slideUp 0.3s ease-out;
+  }
+
+  :global(html.dark) .toast {
+    background: #2c2c2e;
+    border-color: #3a3a3c;
+    color: #e5e5e7;
+    box-shadow: 0 4px 20px rgba(0,0,0,0.3);
+  }
+
+  .toast svg {
+    color: #c0392b;
+    flex-shrink: 0;
+  }
+
+  .toast-text {
+    line-height: 1.35;
+  }
+
+  @keyframes slideUp {
+    from { opacity: 0; transform: translateY(10px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+
+  @media print {
+    .toast-stack { display: none !important; }
+  }
+</style>

--- a/src/lib/renderer/pipeline.ts
+++ b/src/lib/renderer/pipeline.ts
@@ -226,7 +226,7 @@ function resolveRelativeImages(html: string, baseDir: string, collected: string[
   return html.replace(
     /(<img\s[^>]*?\bsrc=")(?!https?:\/\/|data:|blob:|asset:|file:)([^"]+)(")/gi,
     (_match, before, src, after) => {
-      const imagePath = resolveImagePath(src, baseDir);
+      const imagePath = resolveLocalPath(src, baseDir);
       try {
         const url = `${before}${convertFileSrc(imagePath)}${after}`;
         collected.push(imagePath);
@@ -252,7 +252,7 @@ function resolveSrcset(srcset: string, baseDir: string, collected: string[]): st
       if (isExternalSrc(src)) return trimmed;
 
       try {
-        const imagePath = resolveImagePath(src, baseDir);
+        const imagePath = resolveLocalPath(src, baseDir);
         const converted = convertFileSrc(imagePath);
         collected.push(imagePath);
         return [converted, ...descriptor].join(" ");
@@ -266,7 +266,13 @@ function resolveSrcset(srcset: string, baseDir: string, collected: string[]): st
 function isExternalSrc(src: string): boolean {
   return /^(?:https?:\/\/|data:|blob:|asset:|file:)/i.test(src);
 }
-function resolveImagePath(src: string, baseDir: string): string {
+/**
+ * Resolve a local path (image src or markdown link href) against `baseDir`.
+ * Decodes `%20`, passes absolute/Windows paths through, and normalizes `./`,
+ * `../`, and mixed separators. Shared by image rendering and local-file links
+ * (issue #30) so there's a single resolution implementation.
+ */
+export function resolveLocalPath(src: string, baseDir: string): string {
   const decodedSrc = decodeImageSrc(src);
   if (isAbsolutePath(decodedSrc)) return decodedSrc;
   return normalizePath(`${baseDir}/${decodedSrc}`);

--- a/src/lib/stores/toast.ts
+++ b/src/lib/stores/toast.ts
@@ -1,0 +1,23 @@
+import { writable } from "svelte/store";
+
+export interface Toast {
+  id: number;
+  message: string;
+}
+
+export const toasts = writable<Toast[]>([]);
+
+let nextId = 1;
+
+/**
+ * Show a transient toast message. Minimal by design — a single line of text,
+ * auto-dismissed. Used for non-blocking notices like "file not found" from the
+ * local-file-link handler (issue #30).
+ */
+export function showToast(message: string, durationMs = 3500): void {
+  const id = nextId++;
+  toasts.update((list) => [...list, { id, message }]);
+  setTimeout(() => {
+    toasts.update((list) => list.filter((t) => t.id !== id));
+  }, durationMs);
+}

--- a/src/lib/tauri/files.ts
+++ b/src/lib/tauri/files.ts
@@ -127,6 +127,17 @@ export async function resolvePath(path: string): Promise<string> {
   return invoke<string>("resolve_path", { path });
 }
 
+/** Whether a path exists on disk (for the local-file-link existence check, #30). */
+export async function pathExists(path: string): Promise<boolean> {
+  return invoke<boolean>("path_exists", { path });
+}
+
+/** Open a non-markdown local file in the OS default app (#30). */
+export async function openWithSystem(path: string): Promise<void> {
+  const { openPath } = await import("@tauri-apps/plugin-opener");
+  await openPath(path);
+}
+
 /**
  * Whitelist resolved local image paths with the webview's asset protocol so
  * they can be fetched regardless of the static $HOME scope (issue #31). A

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,8 +2,17 @@
   import { onMount, tick } from "svelte";
   import { document as docStore } from "$lib/stores/document";
   import { tabStore, HOME_TAB_ID, type Tab } from "$lib/stores/tabs";
-  import { initRenderer, renderFull } from "$lib/renderer/pipeline";
-  import { allowAssets, getBaseDir, openFile, openFileDialog, saveFile } from "$lib/tauri/files";
+  import { initRenderer, renderFull, resolveLocalPath } from "$lib/renderer/pipeline";
+  import {
+    allowAssets,
+    getBaseDir,
+    openFile,
+    openFileDialog,
+    openWithSystem,
+    pathExists,
+    saveFile,
+  } from "$lib/tauri/files";
+  import { showToast } from "$lib/stores/toast";
   import { settings } from "$lib/stores/settings";
   import { startFileWatcher } from "$lib/tauri/watcher";
   import { themeMode, cycleTheme } from "$lib/stores/theme";
@@ -29,6 +38,7 @@
   import ScrollToTop from "$lib/components/ScrollToTop.svelte";
   import ImageLightbox from "$lib/components/ImageLightbox.svelte";
   import UpdateToast from "$lib/components/UpdateToast.svelte";
+  import Toast from "$lib/components/Toast.svelte";
   import Editor from "$lib/components/Editor.svelte";
   import { updateScrollPercent } from "$lib/stores/recents";
   import { checkForUpdates, updateAvailable, updateDismissed, checkInFlight } from "$lib/stores/updater";
@@ -237,6 +247,79 @@
       console.error("Save failed:", err);
       alert(`Save failed: ${err}`);
     }
+  }
+
+  /**
+   * Open a local file linked from the rendered markdown (issue #30). Resolves
+   * the href against the current document's directory: markdown files open in a
+   * new in-app tab, other files (PDF, images, …) open in the OS default app,
+   * and a missing target surfaces a toast without disturbing the current tab.
+   */
+  async function handleLocalLink(href: string) {
+    const tab = activeTab;
+    // paste:// and url:// tabs have no real base dir to resolve against — keep
+    // the prior external-opener behavior for their links.
+    if (!tab || !tab.filePath || tab.filePath.startsWith("paste://") || tab.filePath.startsWith("url://")) {
+      try {
+        const { openUrl } = await import("@tauri-apps/plugin-opener");
+        await openUrl(href);
+      } catch {}
+      return;
+    }
+
+    // Strip a trailing #fragment / ?query — we open the file, not an in-file
+    // anchor (cross-file anchor scroll is out of scope for now). A bare "#frag"
+    // was already handled as in-page navigation in the renderer.
+    let target = href.replace(/[?#].*$/, "");
+    // file: URLs arrive here (they're local) — reduce to a plain path.
+    target = target.replace(/^file:\/\//i, "");
+    if (!target) return;
+
+    const resolved = resolveLocalPath(target, getBaseDir(tab.filePath));
+    const name = resolved.split(/[\\/]/).pop() || resolved;
+
+    if (!(await pathExists(resolved))) {
+      showToast(`Can't find “${name}”`);
+      return;
+    }
+
+    if (/\.(md|markdown)$/i.test(resolved)) {
+      await openFile(resolved);
+      return;
+    }
+
+    // Security: never hand executable/script types to the OS opener. A clicked
+    // link with deceptive text could otherwise launch a pre-existing payload in
+    // one click. Everything else (PDF, images, docs…) opens in the default app.
+    if (isExecutablePath(resolved)) {
+      showToast(`Won't open executable file “${name}”. Open it from your file manager if you trust it.`);
+      return;
+    }
+
+    try {
+      await openWithSystem(resolved);
+    } catch {
+      showToast(`Couldn't open “${name}”`);
+    }
+  }
+
+  // Extensions that can run code when opened with the OS default handler.
+  const EXECUTABLE_EXTENSIONS = new Set([
+    // macOS / shell / scripting
+    "app", "command", "sh", "bash", "zsh", "scpt", "applescript",
+    "terminal", "workflow", "action", "osascript",
+    // Windows
+    "exe", "bat", "cmd", "com", "scr", "ps1", "vbs", "vbe", "js", "jse",
+    "wsf", "msi", "msp", "cpl", "lnk", "reg", "hta", "pif",
+    // cross-platform
+    "jar",
+  ]);
+
+  function isExecutablePath(path: string): boolean {
+    const name = path.split(/[\\/]/).pop() || "";
+    const dot = name.lastIndexOf(".");
+    if (dot < 0) return false;
+    return EXECUTABLE_EXTENSIONS.has(name.slice(dot + 1).toLowerCase());
   }
 
   function handleEditToggle() {
@@ -825,6 +908,7 @@
         <MarkdownRenderer
           html={$docStore.renderedHtml}
           onImageClick={(src, all, idx) => { lightboxImages = all; lightboxIndex = idx; lightboxVisible = true; }}
+          onLocalLink={handleLocalLink}
         />
       </main>
     {/if}
@@ -837,6 +921,7 @@
     <EmptyState onOpenUrl={() => { pasteDefaultMode = "url"; pasteVisible = true; }} />
   {/if}
   <UpdateToast />
+  <Toast />
 </div>
 
 <style>


### PR DESCRIPTION
Fixes #30.

## What
Clicking a markdown link to a **local file** now opens it, resolved against the current document's directory:
- `.md` / `.markdown` → new **in-app tab** (`openFile`)
- other files (PDF, images, …) → **OS default app**
- relative, `../`-escaping, and absolute paths all work (reuses the path resolution from #26/#31)

Reporter (@phyjswang) asked to open local hyperlinks that previously worked for *neither* relative nor absolute paths.

## Trigger: plain click
The reporter suggested cmd/opt+click; we went with **plain click** — these are reading-focused docs, so a modifier adds friction. Same underlying goal (navigate cross-linked local `.md` files).

## Security
A clicked link with deceptive text could otherwise launch a pre-existing local payload, so the OS-opener path **blocklists executable/script types** (`.app .command .sh .exe .ps1 .bat .vbs .jar …`, case-insensitive, multi-dot safe) → shows a toast instead of opening. `.md` still opens in-app; documents/images still open via the OS. A full audit of the diff (link classification, shell-injection, toast XSS, path traversal, auto-trigger) found nothing else actionable — `javascript:`/`data:` are stripped by DOMPurify upstream and never reach the local-file path; Tauri's opener uses OS APIs (no shell), so filenames can't inject args.

## Changes
- `pipeline.ts` — export `resolveLocalPath` (single resolver shared with image rendering)
- `MarkdownRenderer.svelte` — `onLocalLink` prop + link classification; also fixes the href-preview tooltip lingering after click / re-render
- `+page.svelte` — `handleLocalLink` routing + executable blocklist; mounts the toast
- `files.ts` — `pathExists`, `openWithSystem` wrappers
- `commands.rs` / `lib.rs` — `path_exists` command
- `capabilities/default.json` — opener `open_path` path scope
- new `Toast.svelte` + `toast` store (minimal generic toast)

## Verified locally
- Relative / `../`-escape / absolute `.md` → open in-app ✓
- PDF + image → OS default app ✓
- `.command` / `.sh` / `Calculator.app` → blocked with toast, not executed ✓
- Missing target → toast, current tab undisturbed ✓
- External URL / mailto / #anchor / paste:// tabs → unchanged ✓
- `pnpm check` clean (no new errors), `cargo check` clean

## Note on CI
macOS build may show red on the notarization step — that's the expired Apple Developer agreement (account-side), unrelated to this change.