### PR TITLE
Add viewport width toggle

### DIFF
--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -6,13 +6,13 @@
     onChange,
     fontSize = 14,
     lineHeight = 1.6,
-    maxWidth = 720,
+    maxWidth = "720px",
   }: {
     value: string;
     onChange: (newValue: string) => void;
     fontSize?: number;
     lineHeight?: number;
-    maxWidth?: number;
+    maxWidth?: string;
   } = $props();
 
   let textareaEl: HTMLTextAreaElement | undefined = $state();
@@ -69,7 +69,7 @@
     oninput={handleInput}
     onkeydown={handleKeydown}
     class="editor"
-    style="font-size: {fontSize}px; line-height: {lineHeight}; max-width: {maxWidth}px;"
+    style="font-size: {fontSize}px; line-height: {lineHeight}; max-width: {maxWidth};"
     spellcheck="false"
     autocomplete="off"
     autocapitalize="off"

--- a/src/lib/components/MarkdownRenderer.svelte
+++ b/src/lib/components/MarkdownRenderer.svelte
@@ -2,7 +2,7 @@
   import { onMount, tick } from "svelte";
   import { get } from "svelte/store";
   import { invoke } from "@tauri-apps/api/core";
-  import { settings, fontFamilyMap } from "$lib/stores/settings";
+  import { settings, fontFamilyMap, getContentMaxWidth } from "$lib/stores/settings";
   import { tocEntries, activeHeadingId, extractToc, tocVisible, isObserverPaused } from "$lib/stores/toc";
   import { aiLookup, setPendingSelection } from "$lib/stores/aiLookup";
   import mermaid from "mermaid";
@@ -258,7 +258,7 @@
   class="md-content prose prose-slate dark:prose-invert max-w-none mx-auto px-8 py-8 transition-all"
   class:toc-offset={$tocVisible && $tocEntries.length > 0}
   style="
-    max-width: {$settings.maxWidth}px;
+    max-width: {getContentMaxWidth($settings)};
     font-size: {$settings.fontSize}px;
     line-height: {$settings.lineHeight};
     font-family: {fontFamilyMap[$settings.fontFamily]};

--- a/src/lib/components/ReaderControls.svelte
+++ b/src/lib/components/ReaderControls.svelte
@@ -56,6 +56,26 @@
       />
     </div>
 
+    <div class="rc-group">
+      <span class="rc-label">Width mode</span>
+      <div class="rc-segmented">
+        <button
+          onclick={() => settings.update((s) => ({ ...s, widthMode: "comfortable" }))}
+          class="rc-seg-btn"
+          class:active={$settings.widthMode === "comfortable"}
+        >
+          Comfortable
+        </button>
+        <button
+          onclick={() => settings.update((s) => ({ ...s, widthMode: "wide" }))}
+          class="rc-seg-btn"
+          class:active={$settings.widthMode === "wide"}
+        >
+          Wide
+        </button>
+      </div>
+    </div>
+
     <div class="rc-group" style="margin-bottom: 0;">
       <div class="rc-label-row">
         <span class="rc-label">Content width</span>

--- a/src/lib/components/Toolbar.svelte
+++ b/src/lib/components/Toolbar.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { document } from "../stores/document";
+  import { settings } from "../stores/settings";
   import { themeMode, cycleTheme } from "../stores/theme";
   import { tocVisible, tocEntries, toggleToc, activeHeadingId } from "../stores/toc";
   import { openFileDialog } from "../tauri/files";
@@ -62,6 +63,14 @@
   function handleThemeToggle() {
     closeAll();
     themeMode.update((m) => cycleTheme(m));
+  }
+
+  function toggleWidthMode() {
+    closeAll();
+    settings.update((s) => ({
+      ...s,
+      widthMode: s.widthMode === "wide" ? "comfortable" : "wide",
+    }));
   }
 
   async function handleExportPdf() {
@@ -147,6 +156,31 @@
       title={$document.renderedHtml ? 'Reading preferences (Aa)' : 'Reading preferences (open a file first)'}
     >
       <svg width="20" height="20" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><text x="1" y="12" font-size="12" font-weight="700" stroke="none" fill="currentColor" font-family="-apple-system, BlinkMacSystemFont, sans-serif">Aa</text></svg>
+    </button>
+
+    <button
+      onclick={toggleWidthMode}
+      class="btn btn-icon"
+      class:active={$settings.widthMode === "wide"}
+      disabled={!$document.renderedHtml}
+      title={!$document.renderedHtml
+        ? 'Toggle wide view (open a file first)'
+        : $settings.widthMode === "wide"
+        ? 'Use comfortable width'
+        : 'Use wide viewport'}
+      aria-label={$settings.widthMode === "wide" ? 'Use comfortable width' : 'Use wide viewport'}
+    >
+      <svg width="20" height="20" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M2.5 5.5V3.5h2" />
+        <path d="M13.5 5.5V3.5h-2" />
+        <path d="M2.5 10.5v2h2" />
+        <path d="M13.5 10.5v2h-2" />
+        <path d="M5.5 8h5" />
+        <path d="M4 8l1.5-1.5" />
+        <path d="M4 8l1.5 1.5" />
+        <path d="M12 8l-1.5-1.5" />
+        <path d="M12 8l-1.5 1.5" />
+      </svg>
     </button>
 
     <button

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -5,17 +5,27 @@ export interface ReaderSettings {
   lineHeight: number;
   fontFamily: "sans" | "serif" | "mono";
   maxWidth: number;
+  widthMode: "comfortable" | "wide";
   closeOnEscape: boolean;
 }
 
 const STORAGE_KEY = "mdhero-settings";
+const DEFAULT_MAX_WIDTH = 720;
+const MIN_MAX_WIDTH = 560;
+const MAX_MAX_WIDTH = 3840;
+const WIDE_MAX_WIDTH = "min(3840px, calc(100vw - clamp(48px, 8vw, 128px)))";
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
 
 function loadSettings(): ReaderSettings {
   const defaults: ReaderSettings = {
     fontSize: 17,
     lineHeight: 1.7,
     fontFamily: "sans",
-    maxWidth: 720,
+    maxWidth: DEFAULT_MAX_WIDTH,
+    widthMode: "comfortable",
     closeOnEscape: true,
   };
 
@@ -24,7 +34,13 @@ function loadSettings(): ReaderSettings {
   try {
     const stored = localStorage.getItem(STORAGE_KEY);
     if (stored) {
-      return { ...defaults, ...JSON.parse(stored) };
+      const parsed = { ...defaults, ...JSON.parse(stored) };
+      const storedMaxWidth = Number(parsed.maxWidth) || defaults.maxWidth;
+      return {
+        ...parsed,
+        maxWidth: clamp(storedMaxWidth, MIN_MAX_WIDTH, MAX_MAX_WIDTH),
+        widthMode: parsed.widthMode === "wide" ? "wide" : "comfortable",
+      };
     }
   } catch {}
 
@@ -55,6 +71,10 @@ function createSettingsStore() {
 }
 
 export const settings = createSettingsStore();
+
+export function getContentMaxWidth(value: ReaderSettings): string {
+  return value.widthMode === "wide" ? WIDE_MAX_WIDTH : `${value.maxWidth}px`;
+}
 
 export const fontFamilyMap: Record<string, string> = {
   sans: 'Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,7 +4,7 @@
   import { tabStore, HOME_TAB_ID, type Tab } from "$lib/stores/tabs";
   import { initRenderer, renderFull } from "$lib/renderer/pipeline";
   import { allowAssets, getBaseDir, openFile, openFileDialog, saveFile } from "$lib/tauri/files";
-  import { settings } from "$lib/stores/settings";
+  import { settings, getContentMaxWidth } from "$lib/stores/settings";
   import { startFileWatcher } from "$lib/tauri/watcher";
   import { themeMode, cycleTheme } from "$lib/stores/theme";
   import { getCurrentWindow } from "@tauri-apps/api/window";
@@ -48,6 +48,7 @@
   let customPromptSelection = $state("");
   let zenMode = $state(false);
   let rawMode = $state(false);
+  let contentMaxWidth = $derived(getContentMaxWidth($settings));
 
   // Lightbox state
   let lightboxVisible = $state(false);
@@ -810,13 +811,13 @@
         onChange={(v) => tabStore.updateEditContent(activeTab!.id, v)}
         fontSize={$settings.fontSize}
         lineHeight={$settings.lineHeight}
-        maxWidth={$settings.maxWidth}
+        maxWidth={contentMaxWidth}
       />
     {:else if rawMode}
       <main class="content-main">
         <pre
           class="raw-source"
-          style="font-size: {$settings.fontSize}px; line-height: {$settings.lineHeight}; max-width: {$settings.maxWidth}px;"
+          style="font-size: {$settings.fontSize}px; line-height: {$settings.lineHeight}; max-width: {contentMaxWidth};"
         ><code>{$docStore.content}</code></pre>
       </main>
     {:else}


### PR DESCRIPTION
  ## Summary

  This adds a quick viewport width toggle for the markdown reader.

  Users can now switch between:

  - **Comfortable**: the existing saved content width from Reader Preferences
  - **Wide**: a viewport-aware width that uses more of the available window while keeping responsive side margins

  The toggle is available directly from the toolbar and also as a segmented control in Reading Preferences. The selected mode is persisted with reader settings and is applied
  consistently across rendered markdown, raw markdown, and edit mode.

  ## Changes

  - Added `widthMode` to reader settings: `comfortable | wide`
  - Added a toolbar button for quickly toggling width mode
  - Added a `Comfortable / Wide` control to Reader Preferences
  - Added shared width calculation via `getContentMaxWidth`
  - Updated viewer, raw source, and editor layouts to use the same width mode
  - Kept the original default comfortable width at `720px`

  ## Validation

  - Ran `pnpm build`
  - Ran `pnpm tauri build --bundles app`
  - Verified the generated macOS `.app` bundle with `codesign --verify --deep`

<img width="1499" height="765" alt="image" src="https://github.com/user-attachments/assets/842ac45c-3f0d-4f02-8c7b-8500e931024f" />
