### PR TITLE
fix: remember window size and position across launches (#40)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2269,6 +2269,7 @@ dependencies = [
  "tauri-plugin-opener",
  "tauri-plugin-process",
  "tauri-plugin-updater",
+ "tauri-plugin-window-state",
 ]
 
 [[package]]
@@ -4343,6 +4344,21 @@ dependencies = [
  "url",
  "windows-sys 0.60.2",
  "zip",
+]
+
+[[package]]
+name = "tauri-plugin-window-state"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73736611e14142408d15353e21e3cca2f12a3cfb523ad0ce85999b6d2ef1a704"
+dependencies = [
+ "bitflags 2.11.0",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -27,6 +27,7 @@ serde_json = "1"
 notify = { version = "7", features = ["macos_fsevent"] }
 notify-debouncer-mini = "0.5"
 tauri-plugin-process = "2"
+tauri-plugin-window-state = "2"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-updater = "2"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -12,6 +12,7 @@
     },
     "dialog:default",
     "cli:default",
+    "window-state:default",
     "core:event:default",
     "core:window:default",
     "core:window:allow-set-title",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -30,6 +30,7 @@ fn get_opened_files(state: tauri::State<'_, OpenedFiles>) -> Vec<String> {
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
+        .plugin(tauri_plugin_window_state::Builder::default().build())
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_opener::init())


### PR DESCRIPTION
## Summary

Fixes #40 — the window opened at a fixed 900×700 every time, discarding any resize or reposition the user made.

The window was created from static `tauri.conf.json` geometry with no persistence layer. This adds the official **`tauri-plugin-window-state`**, which saves size/position/maximized state on close and restores it on the next launch.

## Changes
- `Cargo.toml`: add `tauri-plugin-window-state = "2"`
- `lib.rs`: register the plugin
- `capabilities/default.json`: add `window-state:default` permission

## Behavior
- Restores within the existing `minWidth`/`minHeight` bounds.
- First launch (no saved state) falls back to the configured 900×700 default.
- Saves on window close **and** on the close-on-ESC `quit_app` exit path.

## Verification
Verified locally on macOS: resized + moved the window → quit → relaunched → geometry restored exactly across multiple cycles. The plugin wrote `~/Library/Application Support/com.mdhero.app/.window-state.json` with the expected dimensions.

Reporter is on Windows; the fix is platform-agnostic (the bug affected all platforms).