### PR TITLE
fix: drop injected quotation glyphs from blockquotes (#45)

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -5,6 +5,16 @@
 
 @custom-variant dark (&:where(.dark, .dark *));
 
+/* Tailwind Typography wraps blockquote paragraphs in “ ” quote glyphs by
+   default. Drop them: they aren't in the source markdown, and `>` is used for
+   callouts/notes/alerts as often as quotations, where quote marks mislead (#45).
+   Kept global (not in a scoped Svelte block) so it targets the pseudo-elements
+   without scoping quirks, and its higher specificity beats the plugin's rule. */
+.prose blockquote p:first-of-type::before,
+.prose blockquote p:last-of-type::after {
+  content: none;
+}
+
 :root {
   --md-max-width: 720px;
   --md-font-size: 17px;


### PR DESCRIPTION
Fixes #45.

Tailwind Typography wraps blockquote paragraphs in curly-quote glyphs (`content: open-quote` / `close-quote` on `::before`/`::after`). Those characters aren't in the source markdown, so for a viewer whose pitch is reading markdown *as written*, they're a semantic mismatch. And `>` is used for callouts, notes, and alerts as often as quotations — where wrapping quote marks actively mislead.

This overrides the plugin's rule with `content: none`, so blockquotes render as a plain left border (GitHub-style), as @arphox suggested.

## Change
One rule in `src/app.css`:
```css
.prose blockquote p:first-of-type::before,
.prose blockquote p:last-of-type::after {
  content: none;
}
```
Kept in the global stylesheet (not a scoped Svelte block) so it targets the pseudo-elements cleanly; higher specificity than the plugin's `:where()`-wrapped rule.

## Verification
Verified locally: normal quotations, callout-style `> **Note:**` blocks, and multi-paragraph blockquotes render with no injected glyphs — only literal quote characters typed in the source are preserved. Left-border styling unchanged.
