### PR TITLE
feat: middle-click a tab to close it (#46)

### DIFF
--- a/src/lib/components/TabBar.svelte
+++ b/src/lib/components/TabBar.svelte
@@ -16,7 +16,26 @@
     onCloseTab(id);
   }
 
+  // Middle-click anywhere on a tab closes it, matching browsers/VS Code (#46).
+  // auxclick fires exactly once per non-primary click (unlike raw mousedown,
+  // which mis-fires during the row re-render). Routes through onCloseTab so the
+  // same unsaved-changes handling applies as the X button.
+  function handleAuxClick(e: MouseEvent, id: string) {
+    if (e.button !== 1) return;
+    e.preventDefault();
+    onCloseTab(id);
+  }
+
   function handleMouseDown(e: MouseEvent, idx: number) {
+    // Suppress the middle-button default (autoscroll) so the tab close on
+    // auxclick fires cleanly on the first click (#46) — but don't close here;
+    // closing on mousedown mis-fires as the row re-renders. Don't start a drag.
+    if (e.button === 1) {
+      e.preventDefault();
+      return;
+    }
+    // Only the left button starts a drag.
+    if (e.button !== 0) return;
     if ((e.target as HTMLElement).closest(".tab-close")) return;
     e.preventDefault();
     dragIndex = idx;
@@ -77,6 +96,7 @@
         <!-- svelte-ignore a11y_no_static_element_interactions -->
         <div
           onmousedown={(e) => handleMouseDown(e, idx)}
+          onauxclick={(e) => handleAuxClick(e, tab.id)}
           onclick={() => tabStore.switchTab(tab.id)}
           class="tab"
           class:active={$activeTabId === tab.id}


### PR DESCRIPTION
Closes #46.

Middle-click (mouse-wheel button) anywhere on a tab header now closes it, matching browsers, VS Code, and JetBrains. No need to aim at the small X, and it closes background tabs directly without switching to them first — as @arphox requested.

## How it works
- **Close on `auxclick`** (`button === 1`) — the standard event for a completed non-primary click; fires exactly once per middle-click.
- **Middle-`mousedown` only suppresses autoscroll** (`preventDefault`) and returns — it does *not* close there. (Closing on `mousedown` mis-fired during the row re-render and could take two tabs at once; and without suppressing autoscroll the first clicks were eaten.)
- Routes through the existing `onCloseTab` handler, so unsaved-changes handling is **identical to the X button**.
- Left-click switch and drag-to-reorder are gated to the left button (`button === 0`) and unaffected.

## Verification
Verified locally: single middle-click closes exactly one tab (including background tabs, no switch first); repeated/rapid middle-clicks never close two at once; left-click switching and drag-reorder still work.

## Note (separate pre-existing bug)
While testing this, we found that closing a tab with **unsaved changes** doesn't prompt — for the X button too. That's a pre-existing issue: `window.confirm()` silently returns `false` in the Tauri/WKWebView build, so the "Discard unsaved changes?" guard in `handleCloseTab` is dead for *all* close paths. It's unrelated to this change (middle-click faithfully matches the X) and is being fixed separately.
