### PR TITLE
fix: prompt before discarding unsaved changes on tab close

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -11,6 +11,7 @@
       "allow": [{ "path": "**" }]
     },
     "dialog:default",
+    "dialog:allow-ask",
     "cli:default",
     "window-state:default",
     "core:event:default",

--- a/src/lib/components/TabBar.svelte
+++ b/src/lib/components/TabBar.svelte
@@ -17,12 +17,14 @@
   }
 
   // Middle-click anywhere on a tab closes it, matching browsers/VS Code (#46).
-  // auxclick fires exactly once per non-primary click (unlike raw mousedown,
-  // which mis-fires during the row re-render). Routes through onCloseTab so the
-  // same unsaved-changes handling applies as the X button.
+  // Only clean tabs: a dirty tab needs the unsaved-changes dialog, and opening
+  // that native modal from an auxclick handler wedges it in WKWebView (the modal
+  // becomes unresponsive). So middle-click skips dirty tabs — the X button (a
+  // plain click) still closes them with the prompt.
   function handleAuxClick(e: MouseEvent, id: string) {
     if (e.button !== 1) return;
     e.preventDefault();
+    if ($tabs.find((t) => t.id === id)?.dirty) return;
     onCloseTab(id);
   }
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -343,10 +343,26 @@
     switchMode(rawMode ? "viewer" : "raw");
   }
 
-  function handleCloseTab(id: string): boolean {
+  async function handleCloseTab(id: string): Promise<boolean> {
     const t = $tabs.find((x) => x.id === id);
     if (!t) return false;
-    if (t.dirty && !confirm(`Discard unsaved changes to ${t.fileName}?`)) return false;
+    // Native dialog via the plugin — window.confirm() is a no-op in the Tauri
+    // WKWebView (silently returns false), which made this guard dead and closed
+    // dirty tabs without warning.
+    if (t.dirty) {
+      const { ask } = await import("@tauri-apps/plugin-dialog");
+      // The primary/default button (Enter) must be the SAFE action, so a
+      // reflexive Return can't destroy unsaved work. `ask`'s OK button is the
+      // default, so OK = "Keep Editing" and the cancel-position button is the
+      // deliberate, non-default "Discard".
+      const keepEditing = await ask(`You have unsaved changes to ${t.fileName}.`, {
+        title: "Unsaved changes",
+        kind: "warning",
+        okLabel: "Keep Editing",
+        cancelLabel: "Discard",
+      });
+      if (keepEditing) return false;
+    }
     // Flush reading progress before closing — catches the case where user
     // scrolls and closes within the 500ms debounce window
     if (t.id === $activeTabId) {
@@ -354,6 +370,23 @@
     }
     tabStore.closeTab(id);
     return true;
+  }
+
+  // Close-on-ESC: close the active file tab, and quit the app if it was the last
+  // one (on macOS closing the window alone leaves the app in the dock). Async
+  // because the dirty-confirm dialog is — a cancelled discard must not quit.
+  async function closeActiveTabOnEscape() {
+    const tabsBeforeClose = $tabs.length;
+    if (activeTab && activeTab.id !== HOME_TAB_ID) {
+      const closed = await handleCloseTab(activeTab.id);
+      if (closed && tabsBeforeClose === 1) {
+        invoke("quit_app").catch(() => {});
+      }
+    } else if (tabsBeforeClose === 0) {
+      // Active is home tab and no file tabs are open → quit
+      invoke("quit_app").catch(() => {});
+    }
+    // Else: home tab is active with file tabs in background — do nothing.
   }
 
   onMount(() => {
@@ -689,7 +722,7 @@
       e.preventDefault();
       const t = tabStore.getActiveTab();
       if (!t) return;
-      handleCloseTab(t.id);
+      void handleCloseTab(t.id);
       return;
     }
     if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === "f") {
@@ -711,22 +744,9 @@
       // Close-on-ESC: opt-in setting. Ignore in edit mode and when an input is focused
       // (so users typing in search/paste/etc. don't accidentally trigger it).
       if ($settings.closeOnEscape && !activeTab?.isEditing && !isInputFocused()) {
-        const tabsBeforeClose = $tabs.length;
-
-        if (activeTab && activeTab.id !== HOME_TAB_ID) {
-          // Close the current file tab (handleCloseTab manages the dirty prompt)
-          const closed = handleCloseTab(activeTab.id);
-          // If that was the last file tab, quit the app entirely.
-          // On macOS this is required — closing the window leaves the app in the dock.
-          if (closed && tabsBeforeClose === 1) {
-            invoke("quit_app").catch(() => {});
-          }
-        } else if (tabsBeforeClose === 0) {
-          // Active is home tab and no file tabs are open → quit
-          invoke("quit_app").catch(() => {});
-        }
-        // Else: home tab is active with file tabs in background — do nothing
-        // (don't nuke the user's session just because they happened to be on home)
+        // handleCloseTab is async (native dirty-confirm dialog), so the
+        // quit-on-last-tab decision runs in an async helper.
+        closeActiveTabOnEscape();
       }
       return;
     }


### PR DESCRIPTION
## Problem
Closing a tab with unsaved changes silently discarded them — no prompt. `window.confirm()` is a **no-op in the Tauri WKWebView** (it returns `false` immediately), so the dirty-tab guard in `handleCloseTab` was dead for **every** close path: the X button, `Cmd+W`, and close-on-ESC.

This is silent data loss, discovered while testing middle-click-to-close (#46) — but it affects all close paths, not just middle-click.

## Fix
Two commits:

**1. Prompt before closing a dirty tab** — replace the dead `window.confirm()` with the native `@tauri-apps/plugin-dialog` `ask()` dialog (works reliably where the webview `confirm` doesn't).
- The **primary/default button is the safe action — "Keep Editing"** — so a reflexive `Return` can't destroy work. **"Discard"** is the deliberate, non-default choice (mirrors macOS's own unsaved-changes convention).
- `handleCloseTab` becomes async; the close-on-ESC quit-on-last-tab decision moved to an async helper so a cancelled discard never quits.
- Adds the `dialog:allow-ask` capability permission.

**2. Middle-click skips dirty tabs** — opening the native modal from an `auxclick` handler wedges the modal's event loop in WKWebView (it renders but won't dismiss). So middle-click closes only *clean* tabs; dirty tabs are handled by the X button (a plain `click`), which shows the prompt and dismisses correctly. Middle-click on a dirty tab is a safe no-op.

## Verification
Verified locally: X / `Cmd+W` / ESC on a dirty tab all show the dialog; "Keep Editing" (default) preserves the tab and never quits; "Discard" closes. Middle-click closes clean tabs and is a no-op on dirty ones. Clean tabs close with no prompt as before.

## Follow-up (out of scope)
`AILookupSettings.svelte` also uses `window.confirm()` for delete/reset confirmations — same dead-guard issue, lower stakes. Worth a separate pass.
