### PR TITLE
Add Copy Path to tab right-click menu

### DIFF
--- a/src/lib/components/TabBar.svelte
+++ b/src/lib/components/TabBar.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { tabStore, HOME_TAB_ID } from "$lib/stores/tabs";
+  import { tabStore, HOME_TAB_ID, type Tab } from "$lib/stores/tabs";
+  import { copyPath } from "$lib/utils/clipboard";
 
   let {
     onCloseTab = (id: string) => tabStore.closeTab(id),
@@ -10,6 +11,9 @@
   const { tabs, activeTabId } = tabStore;
   let dragIndex = $state(-1);
   let overIndex = $state(-1);
+  let contextMenuTab = $state<Tab | null>(null);
+  let contextMenuPos = $state({ x: 0, y: 0 });
+  let copyFeedback = $state("");
 
   function handleClose(e: MouseEvent, id: string) {
     e.stopPropagation();
@@ -38,7 +42,7 @@
     }
     // Only the left button starts a drag.
     if (e.button !== 0) return;
-    if ((e.target as HTMLElement).closest(".tab-close")) return;
+    if ((e.target as HTMLElement).closest(".tab-close") || (e.target as HTMLElement).closest(".dropdown")) return;
     e.preventDefault();
     dragIndex = idx;
 
@@ -74,6 +78,34 @@
   function handleNewTab() {
     tabStore.goHome();
   }
+
+  // A tab backed by a real file has a canonical absolute path to copy; paste://
+  // and url:// tabs don't (mirrors +page.svelte's canEditActive gate).
+  function isFileTab(tab: Tab): boolean {
+    return !!tab.filePath && !tab.filePath.startsWith("paste://") && !tab.filePath.startsWith("url://");
+  }
+
+  function handleContextMenu(e: MouseEvent, tab: Tab) {
+    if (!isFileTab(tab)) return;
+    e.preventDefault();
+    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+    const menuWidth = 160;
+    contextMenuPos = { x: Math.min(rect.left, window.innerWidth - menuWidth - 8), y: rect.bottom + 4 };
+    contextMenuTab = tab;
+    copyFeedback = "";
+  }
+
+  function closeContextMenu() {
+    contextMenuTab = null;
+    copyFeedback = "";
+  }
+
+  async function handleCopyPath() {
+    if (!contextMenuTab) return;
+    const success = await copyPath(contextMenuTab.filePath);
+    copyFeedback = success ? "Copied!" : "Failed";
+    setTimeout(closeContextMenu, 900);
+  }
 </script>
 
 <div class="tabbar">
@@ -100,6 +132,7 @@
           onmousedown={(e) => handleMouseDown(e, idx)}
           onauxclick={(e) => handleAuxClick(e, tab.id)}
           onclick={() => tabStore.switchTab(tab.id)}
+          oncontextmenu={(e) => handleContextMenu(e, tab)}
           class="tab"
           class:active={$activeTabId === tab.id}
           class:drag-over={overIndex === idx && dragIndex !== idx && dragIndex >= 0}
@@ -130,6 +163,16 @@
     </button>
   </div>
 </div>
+
+{#if contextMenuTab}
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div class="fixed inset-0 z-[9]" onclick={closeContextMenu} onkeydown={() => {}}></div>
+  <div class="dropdown" style="left: {contextMenuPos.x}px; top: {contextMenuPos.y}px;">
+    <button onclick={handleCopyPath} class="dropdown-item">
+      <span>{copyFeedback || "Copy Path"}</span>
+    </button>
+  </div>
+{/if}
 
 <style>
   .tabbar {
@@ -297,6 +340,50 @@
   :global(html.dark) .new-tab-btn:hover {
     background: rgba(255, 255, 255, 0.08);
     color: #22D3EE;
+  }
+
+  .dropdown {
+    position: fixed;
+    width: 160px;
+    background: white;
+    border: 1px solid #e5e5e5;
+    border-radius: 8px;
+    box-shadow: 0 4px 20px rgba(0,0,0,0.08), 0 1px 3px rgba(0,0,0,0.06);
+    z-index: 50;
+    padding: 4px;
+    overflow: hidden;
+  }
+
+  :global(html.dark) .dropdown {
+    background: #2c2c2e;
+    border-color: #3a3a3c;
+    box-shadow: 0 4px 20px rgba(0,0,0,0.3);
+  }
+
+  .dropdown-item {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    padding: 7px 10px;
+    font-size: 12px;
+    color: #1c1c1e;
+    background: none;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    text-align: left;
+  }
+
+  :global(html.dark) .dropdown-item {
+    color: #e5e5e7;
+  }
+
+  .dropdown-item:hover {
+    background: #f2f2f7;
+  }
+
+  :global(html.dark) .dropdown-item:hover {
+    background: #3a3a3c;
   }
 
   @media print {

--- a/src/lib/utils/clipboard.ts
+++ b/src/lib/utils/clipboard.ts
@@ -56,3 +56,15 @@ export async function copyAsMarkdown(markdown: string): Promise<boolean> {
     return false;
   }
 }
+
+/**
+ * Copy a file's absolute path to clipboard.
+ */
+export async function copyPath(path: string): Promise<boolean> {
+  try {
+    await navigator.clipboard.writeText(path);
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
Closes #50.

## Summary

Right-click a file tab → **Copy Path** → the file's absolute path goes to the clipboard, ready to paste into a terminal, another editor, or a script.

In #50 I asked which menu mechanism you'd prefer — a Svelte dropdown like the toolbar's "Copy content" menu, or a native OS menu like `show_ai_context_menu`. Rather than leave the issue sitting, here's the Svelte dropdown version as a concrete proposal: it's frontend-only, needs no Rust, no new plugin, and no new capability. **If you'd rather it be a native menu, say the word and I'll redo it** — the behavior is identical either way, and I don't want to push you toward a mechanism you don't want.

## Changes

- `src/lib/utils/clipboard.ts` — add `copyPath()`, matching the existing `copyAsMarkdown()` shape (`navigator.clipboard.writeText`, returns a boolean).
- `src/lib/components/TabBar.svelte` — `oncontextmenu` on file tabs opens a one-item dropdown; the item copies `tab.filePath` and briefly shows "Copied!" before dismissing.

Notes on fitting existing patterns:

- **Path comes from `tab.filePath`**, already canonicalized in Rust at open time — no new IPC.
- **Visibility reuses the existing gate.** `isFileTab()` applies the same `filePath && !paste:// && !url://` check that `canEditActive` uses in `+page.svelte`. Non-file tabs get no menu at all (the browser default is not suppressed for them). The home tab renders outside the `{#each $tabs}` loop, so it's unaffected.
- **Dropdown styling mirrors the toolbar menu** — same border/radius/shadow/hover values, same `fixed inset-0 z-[9]` click-outside overlay, same ~1.5s "Copied!" feedback idiom (900ms here since the menu dismisses itself).
- `position: fixed` rather than `absolute` because `.tabbar` has `overflow-x: auto`, which would clip a menu positioned inside it.
- One guard added to the existing drag handler so a click inside the menu can't start a tab drag.

## Testing

- [x] Tested in dev mode (`pnpm tauri dev`)
- [x] Works in both light and dark mode
- [x] No regressions in existing features
- [x] `pnpm check` passes

Detail on each, including one caveat:

- **`pnpm check`** — 3 errors / 9 warnings, byte-identical to what `main` reports before this branch (the two `markdown-it-*` declaration errors and `Toolbar.svelte`'s `Property 'print' does not exist on type 'Webview'`). This change adds none of them; I left them alone as out of scope.
- **`pnpm tauri build`** — succeeds; `.app` and `.dmg` bundle cleanly.
- **Manual** — verified in both themes: menu opens on a file tab, positions under it, and `writeText` receives exactly the tab's absolute path (confirmed by intercepting the call). Verified a `paste://` tab shows no menu. Also confirmed no regression to tab switching, closing, or drag-reorder.
- **Caveat, in the interest of honesty:** my manual pass ran against the Vite dev server in a browser rather than inside the Tauri webview, so the clipboard call went through the browser's `navigator.clipboard` (the same API the app uses in production) rather than through a real WKWebView. Worth a 10-second sanity check on your machine. Related: running the frontend outside Tauri, `getCurrentWindow()` in `+page.svelte`'s tab-switch effect throws on the missing IPC bridge and stalls Svelte's render loop — harmless in the shipped app, but it makes browser-based UI testing confusing. Happy to file that separately if it's useful.
