### PR TITLE
fix: warn about unsaved changes when quitting the app (#54)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -57,6 +57,21 @@ pub fn run() {
             let menu = menu::create_menu(&handle)?;
             app.set_menu(menu)?;
 
+            // Red-button (window) close routes through the frontend quit guard
+            // instead of closing, so unsaved changes get a confirm dialog (#54).
+            // Cmd+Q / menu Quit go through the custom "quit" menu event above.
+            // quit_app (AppHandle::exit) is a hard exit that bypasses this, so a
+            // confirmed quit can't loop back here.
+            if let Some(main_window) = app.get_webview_window("main") {
+                let quit_win = main_window.clone();
+                main_window.on_window_event(move |event| {
+                    if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+                        api.prevent_close();
+                        let _ = quit_win.eval("window.__mdhero_quit?.()");
+                    }
+                });
+            }
+
             app.on_menu_event(move |app_handle, event| {
                 if let Some(window) = app_handle.get_webview_window("main") {
                     let id = event.id().as_ref();
@@ -78,6 +93,9 @@ pub fn run() {
                         }
                         "about" => {
                             let _ = window.eval("window.__mdhero_about?.()");
+                        }
+                        "quit" => {
+                            let _ = window.eval("window.__mdhero_quit?.()");
                         }
                         // AI lookup right-click menu items — forward the
                         // structured ID to the frontend router. JSON-stringify

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -23,7 +23,10 @@ pub fn create_menu<R: Runtime>(app: &AppHandle<R>) -> Result<Menu<R>, tauri::Err
             &PredefinedMenuItem::hide_others(app, None)?,
             &PredefinedMenuItem::show_all(app, None)?,
             &PredefinedMenuItem::separator(app)?,
-            &PredefinedMenuItem::quit(app, None)?,
+            // Custom Quit (not PredefinedMenuItem::quit) so Cmd+Q / menu Quit
+            // fire a "quit" menu event instead of terminating outright — the
+            // frontend guards it for unsaved changes (#54).
+            &MenuItem::with_id(app, "quit", "Quit MDHero", true, Some("CmdOrCtrl+Q"))?,
         ],
     )?;
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -416,6 +416,35 @@
     (window as any).__mdhero_about = () => {
       aboutVisible = true;
     };
+    // App-quit guard (#54): the red-button (CloseRequested) and Cmd+Q / menu
+    // Quit (custom "quit" menu item) both route here rather than terminating, so
+    // quitting with unsaved edits gets the same confirm dialog as tab close.
+    // One prompt covers all dirty tabs. On "Keep Editing" we stay; otherwise
+    // (Discard, no dirty tabs, or dialog failure) we quit via quit_app — a hard
+    // exit, so we never trap the user in an app that can't close.
+    (window as any).__mdhero_quit = async () => {
+      const dirty = $tabs.filter((t) => t.dirty);
+      if (dirty.length > 0) {
+        try {
+          const { ask } = await import("@tauri-apps/plugin-dialog");
+          const msg =
+            dirty.length === 1
+              ? `You have unsaved changes to ${dirty[0].fileName}.`
+              : `You have unsaved changes in ${dirty.length} tabs.`;
+          const keepEditing = await ask(msg, {
+            title: "Unsaved changes",
+            kind: "warning",
+            okLabel: "Keep Editing",
+            cancelLabel: "Discard",
+          });
+          if (keepEditing) return;
+        } catch {
+          // Fall through and quit rather than trap the user behind prevent_close.
+        }
+      }
+      saveProgressNow();
+      invoke("quit_app").catch(() => {});
+    };
     (window as any).__mdhero_check_updates = async () => {
       if (get(checkInFlight)) return;
       // Reset dismissal so a manual check always re-surfaces an available update.


### PR DESCRIPTION
Closes #54 (the "at least request to save before closing" ask).

## Problem

Tab-close paths (X button, Cmd+W, ESC) already prompt when a tab has unsaved editor changes. But quitting the **whole app** bypassed that guard and silently dropped in-editor changes:

- Red window button
- Cmd+Q
- Menu → MDHero → Quit

## Fix

Route all three quit paths through a single frontend guard (`window.__mdhero_quit`) that reuses the existing tab-close confirm dialog:

- **Red button** → a `CloseRequested` window handler calls `prevent_close()` and defers to the guard.
- **Cmd+Q / menu Quit** → replaced `PredefinedMenuItem::quit` with a custom `"quit"` menu item (same label + `CmdOrCtrl+Q`) that emits a menu event instead of terminating.

The guard shows one prompt covering all dirty tabs — **Keep Editing** stays, **Discard** (or no dirty tabs, or a dialog failure) quits via `quit_app`. Since `quit_app` is `AppHandle::exit(0)` — a hard process exit nothing intercepts — a confirmed quit can't loop back through the guards, and a dialog failure can never trap the user behind `prevent_close`.

## Scope

Covers the intentional quit paths (red button, Cmd+Q, menu Quit). Does **not** cover crash / Force Quit — surviving those needs draft persistence, tracked separately. Auto-save-to-disk (the reporter's other nice-to-have) is intentionally out of scope.

## Testing

`cargo check` and `pnpm check` clean (no new errors). Verified in `pnpm tauri dev` on macOS:

- [x] Red button / Cmd+Q / menu Quit each show the dialog when a tab is dirty; Keep Editing cancels, Discard quits
- [x] No dirty tabs → quits immediately, no dialog
- [x] Existing tab-close prompts (Cmd+W, ESC-close-last-tab) still work, no double-prompt after discard