### PR TITLE
fix: open empty markdown files instead of dropping to home (#52)

### DIFF
--- a/src/lib/components/Toolbar.svelte
+++ b/src/lib/components/Toolbar.svelte
@@ -206,8 +206,8 @@
       onclick={onEditToggle}
       class="btn btn-icon"
       class:active={isEditing}
-      disabled={!$document.renderedHtml || !canEdit}
-      title={!$document.renderedHtml
+      disabled={!canEdit}
+      title={!$document.filePath
         ? 'Edit (open a file first)'
         : !canEdit
         ? 'Edit (only available for local files)'

--- a/src/lib/tauri/files.ts
+++ b/src/lib/tauri/files.ts
@@ -38,7 +38,11 @@ export async function openFile(path: string): Promise<void> {
     // HTML hits the DOM, so images outside the static $HOME scope load (#31).
     await allowAssets(result.assetPaths);
 
-    tabStore.addTab(absolutePath, fileName, content, result.html, result.frontmatter, result.wordCount);
+    const tabId = tabStore.addTab(absolutePath, fileName, content, result.html, result.frontmatter, result.wordCount);
+
+    // An empty file has nothing to read — drop straight into the editor so the
+    // user can start writing, instead of staring at a blank viewer (#52).
+    if (content.trim() === "") tabStore.setEditing(tabId, true);
 
     document.set({
       filePath: absolutePath,

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -978,7 +978,10 @@
         <p class="error-msg">{$docStore.error}</p>
       </div>
     </div>
-  {:else if $docStore.renderedHtml}
+  {:else if $docStore.filePath}
+    <!-- Gate on filePath, not renderedHtml: an empty file renders to empty HTML,
+         and gating on that dropped the user back to the home/recents view with no
+         way to edit (#52). A real (even empty) file tab always shows here. -->
     {#if activeTab?.isEditing}
       <Editor
         value={activeTab.editContent}


### PR DESCRIPTION
Closes #52.

## Problem

Opening an empty `.md` file — or selecting-all + deleting + saving an existing one — bounced the user to the home/recents view with no way to edit it. Reported on Windows, but it reproduces everywhere: the empty-then-save path is platform-independent.

Root cause: both the document view and the toolbar used **rendered HTML** as their "a file is open" signal. An empty file renders to empty HTML, so the view fell through to `<EmptyState>` and every toolbar button disabled.

## Fix

1. **Gate the document view on `$docStore.filePath`, not `renderedHtml`** — a real (even empty) file tab always shows its (blank) document instead of the home screen.
2. **Auto-enter edit mode for an empty file** — there's nothing to read, so drop straight into writing (the reporter's preferred option 1).
3. **Gate the toolbar Edit button on `canEdit`, not `renderedHtml`** — otherwise exiting edit mode (Cmd+E) on an empty file stranded the user with a disabled Edit button and a blank viewer, reachable back only via a shortcut they might not know.

## Testing

`pnpm check` clean (no new errors). Verified in `pnpm tauri dev` on macOS:

- [x] Opening an empty file lands directly in edit mode
- [x] Delete-all + save stays on the blank document, no bounce to recents
- [x] A normal non-empty file still opens in the viewer (not forced into edit)
- [x] After Cmd+E to viewer on an empty file, the toolbar Edit button is enabled and returns to edit