### PR TITLE
feat: minimal Marp presentation mode (#44)

### DIFF
--- a/marp-demo.md
+++ b/marp-demo.md
@@ -1,0 +1,65 @@
+---
+marp: true
+title: MDHero — Marp Demo
+paginate: true
+---
+
+# MDHero Marp Demo
+
+A **minimal Marp** presentation, rendered natively.
+
+- `←` / `→` (or PageUp/Down, Space) to move
+- `Home` / `End` to jump to first / last
+- `Esc` to exit
+
+---
+
+## Why this slide won't split
+
+The `---` below lives inside a code fence, so it must **not** start a new slide:
+
+```yaml
+marp: true
+title: A deck
+---
+key: value
+```
+
+If splitting were regex-based, this slide would break in two. It shouldn't.
+
+---
+
+## Rich content works
+
+Inline math renders: $E = mc^2$
+
+A block equation:
+
+$$
+\int_{0}^{\infty} e^{-x^2}\,dx = \frac{\sqrt{\pi}}{2}
+$$
+
+1. Ordered lists
+2. **Bold** and *italic*
+3. `inline code`
+
+---
+
+## A diagram
+
+```mermaid
+flowchart LR
+  A[Open .md] --> B{marp: true?}
+  B -- yes --> C[Present]
+  B -- no --> D[Read normally]
+```
+
+Mermaid should render inside the slide.
+
+---
+
+## Last slide
+
+> Themes, backgrounds, and headers are intentionally out of scope for v1.
+
+That's the whole first cut — thanks for reviewing!

--- a/src/lib/components/PresentationView.svelte
+++ b/src/lib/components/PresentationView.svelte
@@ -1,0 +1,203 @@
+<script lang="ts">
+  import { splitSlides } from "$lib/renderer/slides";
+  import { renderFull, stripFrontmatter } from "$lib/renderer/pipeline";
+  import MarkdownRenderer from "./MarkdownRenderer.svelte";
+
+  let {
+    content,
+    baseDir = "",
+    paginate = false,
+    onExit = () => {},
+    onLocalLink,
+  }: {
+    content: string;
+    baseDir?: string;
+    paginate?: boolean;
+    onExit?: () => void;
+    onLocalLink?: (href: string) => void;
+  } = $props();
+
+  // Split once per content change, then render each slide's HTML up front so
+  // navigation is instant (decks are small; assets were already whitelisted when
+  // the file opened, so no per-slide allow_assets call is needed).
+  let slideHtmls = $derived(
+    splitSlides(stripFrontmatter(content)).map((s) => renderFull(s, baseDir).html)
+  );
+
+  let current = $state(0);
+
+  // Keep the index valid if the deck shrinks (e.g. after an edit).
+  $effect(() => {
+    if (current > slideHtmls.length - 1) current = Math.max(0, slideHtmls.length - 1);
+  });
+
+  const total = $derived(slideHtmls.length);
+
+  function go(delta: number) {
+    current = Math.min(total - 1, Math.max(0, current + delta));
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    switch (e.key) {
+      case "ArrowRight":
+      case "PageDown":
+      case " ":
+        e.preventDefault();
+        go(1);
+        break;
+      case "ArrowLeft":
+      case "PageUp":
+        e.preventDefault();
+        go(-1);
+        break;
+      case "Home":
+        e.preventDefault();
+        current = 0;
+        break;
+      case "End":
+        e.preventDefault();
+        current = total - 1;
+        break;
+      case "Escape":
+        e.preventDefault();
+        e.stopPropagation();
+        onExit();
+        break;
+    }
+  }
+</script>
+
+<svelte:window onkeydown={handleKeydown} />
+
+<div class="present-root" role="presentation">
+  <button class="present-close" onclick={onExit} title="Exit presentation (Esc)" aria-label="Exit presentation">
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"><line x1="3" y1="3" x2="13" y2="13"/><line x1="13" y1="3" x2="3" y2="13"/></svg>
+  </button>
+
+  <button class="nav-edge left" onclick={() => go(-1)} disabled={current === 0} aria-label="Previous slide">
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><polyline points="15,4 7,12 15,20"/></svg>
+  </button>
+
+  <div class="stage">
+    {#key current}
+      <div class="slide">
+        <MarkdownRenderer html={slideHtmls[current] ?? ""} {onLocalLink} />
+      </div>
+    {/key}
+    {#if paginate && total > 0}
+      <div class="counter">{current + 1} / {total}</div>
+    {/if}
+  </div>
+
+  <button class="nav-edge right" onclick={() => go(1)} disabled={current >= total - 1} aria-label="Next slide">
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><polyline points="9,4 17,12 9,20"/></svg>
+  </button>
+</div>
+
+<style>
+  .present-root {
+    position: fixed;
+    inset: 0;
+    z-index: 50;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 24px;
+    background: #0e0e10;
+  }
+
+  .stage {
+    position: relative;
+    width: min(100%, calc((100vh - 96px) * 16 / 9));
+    aspect-ratio: 16 / 9;
+    background: #ffffff;
+    border-radius: 10px;
+    box-shadow: 0 8px 40px rgba(0, 0, 0, 0.5);
+    overflow: hidden;
+    display: flex;
+  }
+
+  :global(html.dark) .stage {
+    background: #1c1c1e;
+  }
+
+  /* The slide scrolls internally if its content overflows the 16:9 frame. */
+  .slide {
+    flex: 1;
+    overflow-y: auto;
+    padding: 6% 8%;
+  }
+
+  /* Neutralize MarkdownRenderer's own centering/width cap inside the stage. */
+  .slide :global(.md-content) {
+    max-width: none !important;
+    margin: 0 !important;
+    padding: 0 !important;
+  }
+
+  .counter {
+    position: absolute;
+    right: 18px;
+    bottom: 14px;
+    font-size: 13px;
+    font-variant-numeric: tabular-nums;
+    color: #8e8e93;
+    background: rgba(0, 0, 0, 0.04);
+    padding: 2px 8px;
+    border-radius: 999px;
+    pointer-events: none;
+  }
+
+  :global(html.dark) .counter {
+    color: #aeaeb2;
+    background: rgba(255, 255, 255, 0.06);
+  }
+
+  .nav-edge {
+    flex-shrink: 0;
+    width: 44px;
+    height: 44px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: none;
+    border-radius: 50%;
+    background: transparent;
+    color: #8e8e93;
+    cursor: pointer;
+    transition: color 0.15s, background 0.15s;
+  }
+
+  .nav-edge:hover:not(:disabled) {
+    color: #f2f2f7;
+    background: rgba(255, 255, 255, 0.08);
+  }
+
+  .nav-edge:disabled {
+    opacity: 0.25;
+    cursor: default;
+  }
+
+  .present-close {
+    position: absolute;
+    top: 16px;
+    right: 16px;
+    width: 32px;
+    height: 32px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: none;
+    border-radius: 8px;
+    background: transparent;
+    color: #8e8e93;
+    cursor: pointer;
+    transition: color 0.15s, background 0.15s;
+  }
+
+  .present-close:hover {
+    color: #f2f2f7;
+    background: rgba(255, 255, 255, 0.08);
+  }
+</style>

--- a/src/lib/components/SettingsDialog.svelte
+++ b/src/lib/components/SettingsDialog.svelte
@@ -44,6 +44,19 @@
               class="setting-switch"
             />
           </label>
+
+          <label class="setting-row">
+            <div class="setting-text">
+              <span class="setting-label">Auto-present Marp decks</span>
+              <span class="setting-hint">Open documents with <code>marp: true</code> frontmatter as a slideshow.</span>
+            </div>
+            <input
+              type="checkbox"
+              checked={$settings.autoPresentMarp}
+              onchange={(e) => settings.update((s) => ({ ...s, autoPresentMarp: e.currentTarget.checked }))}
+              class="setting-switch"
+            />
+          </label>
         </section>
 
         <section class="settings-section">

--- a/src/lib/components/Toolbar.svelte
+++ b/src/lib/components/Toolbar.svelte
@@ -20,6 +20,9 @@
     onEditToggle = () => {},
     onSave = () => {},
     onOpenSettings = () => {},
+    canPresent = false,
+    presenting = false,
+    onTogglePresent = () => {},
   }: {
     onPaste?: () => void;
     onOpen?: () => void;
@@ -32,6 +35,9 @@
     onEditToggle?: () => void;
     onSave?: () => void;
     onOpenSettings?: () => void;
+    canPresent?: boolean;
+    presenting?: boolean;
+    onTogglePresent?: () => void;
   } = $props();
 
   let currentHeading = $derived(
@@ -199,6 +205,22 @@
         <line x1="9" y1="3" x2="7" y2="13"/>
       </svg>
     </button>
+
+    {#if canPresent}
+      <button
+        onclick={onTogglePresent}
+        class="btn btn-icon"
+        class:active={presenting}
+        title={presenting ? 'Exit presentation (Esc)' : 'Present slideshow'}
+        aria-label={presenting ? 'Exit presentation' : 'Present slideshow'}
+      >
+        <svg width="20" height="20" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <rect x="1.5" y="2.5" width="13" height="9" rx="1"/>
+          <line x1="6" y1="14" x2="10" y2="14"/>
+          <line x1="8" y1="11.5" x2="8" y2="14"/>
+        </svg>
+      </button>
+    {/if}
 
     <div class="separator"></div>
 

--- a/src/lib/renderer/pipeline.ts
+++ b/src/lib/renderer/pipeline.ts
@@ -72,6 +72,31 @@ export interface RenderResult {
    * are otherwise refused (issue #31).
    */
   assetPaths: string[];
+  /** True when the frontmatter declares `marp: true` — a Marp slide deck (#44). */
+  isMarp: boolean;
+}
+
+/**
+ * Whether a parsed frontmatter block marks the document as a Marp deck. The
+ * naive frontmatter parser stores values as strings, so `marp: true` arrives as
+ * the string `"true"`; accept both that and a real boolean.
+ */
+export function isMarpDoc(frontmatter: Record<string, unknown> | null): boolean {
+  const v = frontmatter?.marp;
+  return v === true || v === "true";
+}
+
+/** Matches a leading `---\n…\n---\n` frontmatter block (same shape renderFull strips). */
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n([\s\S]*)$/;
+
+/**
+ * Return the markdown body with any leading YAML-ish frontmatter block removed.
+ * `renderFull` strips frontmatter internally, but the stored document content
+ * keeps it — Marp slide splitting needs the body without it (#44).
+ */
+export function stripFrontmatter(markdown: string): string {
+  const m = markdown.match(FRONTMATTER_RE);
+  return m ? m[2] : markdown;
 }
 
 let md: MarkdownIt | null = null;
@@ -219,7 +244,7 @@ export function renderFull(markdown: string, baseDir?: string): RenderResult {
     html = resolveRelativeImages(html, baseDir, assetPaths);
   }
 
-  return { html, frontmatter, wordCount, assetPaths };
+  return { html, frontmatter, wordCount, assetPaths, isMarp: isMarpDoc(frontmatter) };
 }
 
 function resolveRelativeImages(html: string, baseDir: string, collected: string[]): string {

--- a/src/lib/renderer/slides.ts
+++ b/src/lib/renderer/slides.ts
@@ -1,0 +1,49 @@
+// Slide splitting for minimal Marp presentation support (issue #44).
+//
+// A Marp deck separates slides with a top-level thematic break (`---`). Splitting
+// the raw source with a naive `/^---$/m` regex is wrong: a `---` inside a fenced
+// code block, or a `---` used as a setext heading underline, is NOT a slide
+// break. So we let markdown-it tokenize the content and split only on real `hr`
+// tokens — correct by construction, and reusing the parser we already ship.
+//
+// Kept as a pure helper with its own bare parser (independent of the render
+// pipeline's configured instance) so it stays trivially unit-testable.
+
+import MarkdownIt from "markdown-it";
+
+const parser = new MarkdownIt();
+
+/**
+ * Split Marp deck content (the markdown *after* frontmatter) into slides on
+ * top-level `---` thematic breaks.
+ *
+ * - `---` inside a fenced code block is not a break (it's a `fence` token).
+ * - `text` followed by `---` is a setext H2 underline, not a break.
+ * - Empty slices (leading `---`, consecutive `---`) are dropped.
+ * - Content with no break yields a single slide.
+ * - Empty/whitespace-only input yields `[]`.
+ */
+export function splitSlides(content: string): string[] {
+  if (!content.trim()) return [];
+
+  const lines = content.split("\n");
+  const tokens = parser.parse(content, {});
+
+  // 0-indexed start line of every top-level thematic break.
+  const breakLines: number[] = [];
+  for (const token of tokens) {
+    if (token.type === "hr" && token.level === 0 && token.map) {
+      breakLines.push(token.map[0]);
+    }
+  }
+
+  const slides: string[] = [];
+  let start = 0;
+  for (const brk of breakLines) {
+    slides.push(lines.slice(start, brk).join("\n"));
+    start = brk + 1; // skip the `---` line itself
+  }
+  slides.push(lines.slice(start).join("\n"));
+
+  return slides.map((s) => s.trim()).filter((s) => s.length > 0);
+}

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -8,6 +8,8 @@ export interface ReaderSettings {
   widthMode: "comfortable" | "wide";
   closeOnEscape: boolean;
   showLineNumbers: boolean;
+  /** Auto-open `marp: true` documents as a slideshow (#44). */
+  autoPresentMarp: boolean;
 }
 
 const STORAGE_KEY = "mdhero-settings";
@@ -29,6 +31,7 @@ function loadSettings(): ReaderSettings {
     widthMode: "comfortable",
     closeOnEscape: true,
     showLineNumbers: true,
+    autoPresentMarp: true,
   };
 
   if (typeof localStorage === "undefined") return defaults;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,7 +2,7 @@
   import { onMount, tick } from "svelte";
   import { document as docStore } from "$lib/stores/document";
   import { tabStore, HOME_TAB_ID, type Tab } from "$lib/stores/tabs";
-  import { initRenderer, renderFull, resolveLocalPath } from "$lib/renderer/pipeline";
+  import { initRenderer, renderFull, resolveLocalPath, isMarpDoc } from "$lib/renderer/pipeline";
   import {
     allowAssets,
     getBaseDir,
@@ -40,6 +40,7 @@
   import UpdateToast from "$lib/components/UpdateToast.svelte";
   import Toast from "$lib/components/Toast.svelte";
   import Editor from "$lib/components/Editor.svelte";
+  import PresentationView from "$lib/components/PresentationView.svelte";
   import { updateScrollPercent } from "$lib/stores/recents";
   import { checkForUpdates, updateAvailable, updateDismissed, checkInFlight } from "$lib/stores/updater";
   import { get } from "svelte/store";
@@ -58,6 +59,7 @@
   let customPromptSelection = $state("");
   let zenMode = $state(false);
   let rawMode = $state(false);
+  let presenting = $state(false);
   let contentMaxWidth = $derived(getContentMaxWidth($settings));
 
   // Lightbox state
@@ -164,6 +166,22 @@
     activeTab?.isEditing ? "editor" : rawMode ? "raw" : "viewer"
   );
 
+  // Marp presentation (#44). `presenting` is a page-level view mode (like rawMode);
+  // it's only meaningful when the active doc is a Marp deck.
+  let activeIsMarp = $derived(isMarpDoc($docStore.frontmatter));
+  let activePaginate = $derived(
+    $docStore.frontmatter?.paginate === true || $docStore.frontmatter?.paginate === "true"
+  );
+
+  function togglePresent() {
+    presenting = !presenting;
+    if (presenting) {
+      // Entering the slideshow supersedes raw/edit.
+      rawMode = false;
+      if (activeTab?.isEditing) tabStore.setEditing(activeTab.id, false);
+    }
+  }
+
   /**
    * Switch view mode while preserving the source-line position so the user
    * stays anchored at the same place in the document.
@@ -171,6 +189,9 @@
   function switchMode(target: ViewMode) {
     if (!activeTab || target === currentMode) return;
     if (target === "editor" && !canEditActive) return;
+
+    // An explicit mode switch (raw/edit) leaves the slideshow (#44).
+    presenting = false;
 
     // Close the find overlay on any mode change so a search started against one
     // target (viewer/raw/editor) can't leave a stale match count or highlights
@@ -764,6 +785,9 @@
     if (e.key === "Escape") {
       if (zenMode) { zenMode = false; return; }
 
+      // Exit the Marp slideshow before any modal/close-tab handling (#44).
+      if (presenting) { presenting = false; return; }
+
       // Modals/overlays consume ESC first. Inner handlers stopPropagation when focus
       // is inside them; this guard covers the focus-outside case (modal visible but
       // user clicked elsewhere) so we don't nuke the tab while a modal is still up.
@@ -879,6 +903,7 @@
 
     if (!id || id === HOME_TAB_ID) {
       rawMode = false;
+      presenting = false;
       docStore.set({
         filePath: null,
         fileName: null,
@@ -908,6 +933,10 @@
       loading: false,
       error: null,
     });
+
+    // Auto-present a Marp deck on activation when the setting is on and we're not
+    // mid-edit (#44). Runs once per tab switch, so an explicit exit (Esc) sticks.
+    presenting = isMarpDoc(tab.frontmatter) && get(settings).autoPresentMarp && !tab.isEditing;
 
     getCurrentWindow().setTitle(`${tab.fileName} — MDHero`).catch(() => {});
 
@@ -949,6 +978,9 @@
       onEditToggle={handleEditToggle}
       onSave={() => activeTab && handleSave(activeTab)}
       onOpenSettings={() => (settingsVisible = true)}
+      canPresent={activeIsMarp}
+      presenting={presenting}
+      onTogglePresent={togglePresent}
     />
     <TabBar onCloseTab={handleCloseTab} />
   {/if}
@@ -982,7 +1014,15 @@
     <!-- Gate on filePath, not renderedHtml: an empty file renders to empty HTML,
          and gating on that dropped the user back to the home/recents view with no
          way to edit (#52). A real (even empty) file tab always shows here. -->
-    {#if activeTab?.isEditing}
+    {#if presenting && activeIsMarp}
+      <PresentationView
+        content={$docStore.content}
+        baseDir={activeTab ? getBaseDir(activeTab.filePath) : ""}
+        paginate={activePaginate}
+        onExit={() => (presenting = false)}
+        onLocalLink={handleLocalLink}
+      />
+    {:else if activeTab?.isEditing}
       <Editor
         value={activeTab.editContent}
         onChange={(v) => tabStore.updateEditContent(activeTab!.id, v)}
@@ -1008,7 +1048,7 @@
         />
       </main>
     {/if}
-    {#if !zenMode && !activeTab?.isEditing}
+    {#if !zenMode && !activeTab?.isEditing && !presenting}
       <StatusBar />
       <ScrollToTop />
     {/if}

--- a/tests/unit/slides.test.ts
+++ b/tests/unit/slides.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { splitSlides } from "../../src/lib/renderer/slides";
+
+describe("splitSlides", () => {
+  it("returns [] for empty or whitespace-only content", () => {
+    expect(splitSlides("")).toEqual([]);
+    expect(splitSlides("   \n\n  ")).toEqual([]);
+  });
+
+  it("returns a single slide when there is no break", () => {
+    expect(splitSlides("# Title\n\nhello")).toEqual(["# Title\n\nhello"]);
+  });
+
+  it("splits on a top-level thematic break", () => {
+    expect(splitSlides("slide one\n\n---\n\nslide two")).toEqual([
+      "slide one",
+      "slide two",
+    ]);
+  });
+
+  it("splits into three slides", () => {
+    expect(splitSlides("a\n\n---\n\nb\n\n---\n\nc")).toEqual(["a", "b", "c"]);
+  });
+
+  it("does NOT split on `---` inside a fenced code block", () => {
+    const deck = "intro\n\n```yaml\nmarp: true\n---\nkey: val\n```\n\n---\n\nnext";
+    const slides = splitSlides(deck);
+    expect(slides).toHaveLength(2);
+    expect(slides[0]).toContain("```yaml");
+    expect(slides[0]).toContain("marp: true");
+    expect(slides[1]).toBe("next");
+  });
+
+  it("does NOT split on a setext heading underline", () => {
+    // "Title\n---" is an H2 underline, not a thematic break → one slide.
+    const slides = splitSlides("Title\n---\n\nbody");
+    expect(slides).toHaveLength(1);
+  });
+
+  it("drops empty slides from consecutive breaks", () => {
+    expect(splitSlides("a\n\n---\n\n---\n\nb")).toEqual(["a", "b"]);
+  });
+
+  it("drops an empty leading slide", () => {
+    expect(splitSlides("---\n\nfirst")).toEqual(["first"]);
+  });
+
+  it("drops an empty trailing slide", () => {
+    expect(splitSlides("last\n\n---\n")).toEqual(["last"]);
+  });
+
+  it("preserves inner markdown structure of a slide", () => {
+    const slides = splitSlides("# Heading\n\n- a\n- b\n\n---\n\n> quote");
+    expect(slides[0]).toBe("# Heading\n\n- a\n- b");
+    expect(slides[1]).toBe("> quote");
+  });
+});


### PR DESCRIPTION
Closes #44.

## What

Render a `marp: true` document as a native slideshow — **no Marp CLI, no extra dependency**. Auto-presents on open (toggleable), with a toolbar Present button and Esc to exit.

## How

- **`slides.ts`** — split the deck on top-level `---` thematic breaks by walking **markdown-it `hr` tokens**, not a regex. A `---` inside a code fence (a `fence` token) or a setext-heading underline is therefore never mistaken for a slide break. Pure, dependency-light helper.
- **`PresentationView.svelte`** — 16:9 slide overlay; `←/→`, `PageUp/Down`, `Space`, `Home`/`End` navigation; optional `paginate: true` slide numbers; reuses the render pipeline + local-link handling.
- **`pipeline.ts`** — `isMarpDoc()` (accepts real boolean or the string `"true"` from the frontmatter parser), `stripFrontmatter()`, and `isMarp` on `RenderResult`.
- **Integration** — `presenting` is a page-level view mode (like raw/edit): entering supersedes raw/edit; explicit mode switches leave it; **Esc exits the deck ahead of modal/close-tab handling**. Auto-present controlled by `settings.autoPresentMarp` (default on).

## Testing

`pnpm check` clean (no new errors). `pnpm test` — **28/28 pass**, including **10 slide-splitter tests** (code-fence `---`, setext underline, leading/consecutive breaks, no-break single slide, empty input). Verified in `pnpm tauri dev` on macOS with `marp-demo.md`:

- [x] `marp: true` doc auto-opens as a slideshow
- [x] Arrow / PageUp-Down / Space / Home / End navigation
- [x] `paginate: true` shows slide numbers
- [x] `---` inside a code fence does **not** split
- [x] Esc exits to the normal doc; toolbar Present toggles back
- [x] Auto-present setting off → opens as a normal doc with Present available
- [x] Non-Marp docs unaffected (no Present button)

## Notes

Rebased onto current `main`, so it sits on top of the line-numbers (#53) and empty-file (#52) work; both re-verified. `marp-demo.md` is included as a demo/manual-test fixture.