### PR TITLE
feat: View/Split/Edit mode switcher with live split preview (#19)

### DIFF
--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -10,6 +10,7 @@
     lineHeight = 1.6,
     maxWidth = "720px",
     showLineNumbers = false,
+    split = false,
   }: {
     value: string;
     onChange: (newValue: string) => void;
@@ -17,6 +18,7 @@
     lineHeight?: number;
     maxWidth?: string;
     showLineNumbers?: boolean;
+    split?: boolean;
   } = $props();
 
   let textareaEl: HTMLTextAreaElement | undefined = $state();
@@ -159,7 +161,7 @@
   }
 </script>
 
-<div class="editor-wrap">
+<div class="editor-wrap" class:split>
   <div class="editor-stack" class:with-gutter={showLineNumbers} style="max-width: {maxWidth}; --gutter-w: {gutterWidth};">
     {#if showLineNumbers}
       <!-- Line-number gutter: a transparent mirror wrapping identically to the
@@ -217,6 +219,17 @@
 
   :global(html.dark) .editor-wrap {
     background: #161618;
+  }
+
+  /* Split mode (#19): editor occupies the left half; the preview pane (in
+     +page) fills the right half. A divider marks the seam. */
+  .editor-wrap.split {
+    right: 50%;
+    border-right: 1px solid #e5e5e5;
+  }
+
+  :global(html.dark) .editor-wrap.split {
+    border-right-color: #2c2c2e;
   }
 
   .editor-stack {

--- a/src/lib/components/Toolbar.svelte
+++ b/src/lib/components/Toolbar.svelte
@@ -17,7 +17,8 @@
     isEditing = false,
     dirty = false,
     canEdit = false,
-    onEditToggle = () => {},
+    editMode = "view",
+    onSetMode = (_m: "view" | "split" | "edit") => {},
     onSave = () => {},
     onOpenSettings = () => {},
     canPresent = false,
@@ -32,7 +33,8 @@
     isEditing?: boolean;
     dirty?: boolean;
     canEdit?: boolean;
-    onEditToggle?: () => void;
+    editMode?: "view" | "split" | "edit";
+    onSetMode?: (m: "view" | "split" | "edit") => void;
     onSave?: () => void;
     onOpenSettings?: () => void;
     canPresent?: boolean;
@@ -136,6 +138,41 @@
     {/if}
   </div>
 
+  <!-- View / Split / Edit segmented control, centered in the toolbar. Split &
+       Edit need an editable local file; when there isn't one they disable with
+       an explaining tip. -->
+  <div class="toolbar-center">
+    <div
+      class="mode-segmented"
+      role="group"
+      aria-label="View mode"
+      title={!$document.filePath
+        ? 'View · Split · Edit (open a file first)'
+        : !canEdit
+        ? 'Split and Edit are only available for local files'
+        : 'View · Split · Edit'}
+    >
+      <button
+        class="mode-seg"
+        class:active={editMode === 'view'}
+        onclick={() => onSetMode('view')}
+        disabled={!$document.filePath}
+      >View</button>
+      <button
+        class="mode-seg"
+        class:active={editMode === 'split'}
+        onclick={() => onSetMode('split')}
+        disabled={!canEdit}
+      >Split</button>
+      <button
+        class="mode-seg"
+        class:active={editMode === 'edit'}
+        onclick={() => onSetMode('edit')}
+        disabled={!canEdit}
+      >Edit</button>
+    </div>
+  </div>
+
   <div class="toolbar-right">
     <button
       onclick={toggleToc}
@@ -221,27 +258,6 @@
         </svg>
       </button>
     {/if}
-
-    <div class="separator"></div>
-
-    <button
-      onclick={onEditToggle}
-      class="btn btn-icon"
-      class:active={isEditing}
-      disabled={!canEdit}
-      title={!$document.filePath
-        ? 'Edit (open a file first)'
-        : !canEdit
-        ? 'Edit (only available for local files)'
-        : isEditing
-        ? 'Exit edit mode (Cmd+E)'
-        : 'Edit (Cmd+E)'}
-    >
-      <svg width="20" height="20" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-        <path d="M11.5 2.5l2 2-8 8H3.5v-2l8-8z"/>
-        <path d="M10 4l2 2"/>
-      </svg>
-    </button>
 
     <button
       onclick={onSave}
@@ -389,6 +405,17 @@
     gap: 2px;
   }
 
+  /* Centered mode switcher: absolutely centered in the toolbar so it stays put
+     regardless of the left/right group widths. Anchors to .toolbar (sticky). */
+  .toolbar-center {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    display: flex;
+    align-items: center;
+  }
+
   .btn-group {
     display: flex;
     gap: 1px;
@@ -508,6 +535,57 @@
 
   :global(html.dark) .separator {
     background: #3a3a3c;
+  }
+
+  /* View / Split / Edit segmented control */
+  .mode-segmented {
+    display: inline-flex;
+    align-items: stretch;
+    height: 28px;
+    padding: 2px;
+    gap: 2px;
+    background: #e8e8ed;
+    border-radius: 7px;
+  }
+
+  :global(html.dark) .mode-segmented {
+    background: #2c2c2e;
+  }
+
+  .mode-seg {
+    border: none;
+    background: transparent;
+    color: #5f6368;
+    font-size: 12px;
+    font-weight: 500;
+    padding: 0 10px;
+    border-radius: 5px;
+    cursor: pointer;
+    transition: background 0.12s, color 0.12s;
+  }
+
+  .mode-seg:hover:not(:disabled):not(.active) {
+    color: #1c1c1e;
+  }
+
+  :global(html.dark) .mode-seg:hover:not(:disabled):not(.active) {
+    color: #e5e5e7;
+  }
+
+  .mode-seg.active {
+    background: #ffffff;
+    color: #0891b2;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+  }
+
+  :global(html.dark) .mode-seg.active {
+    background: #48484a;
+    color: #22d3ee;
+  }
+
+  .mode-seg:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
   }
 
   .dropdown {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -60,6 +60,12 @@
   let zenMode = $state(false);
   let rawMode = $state(false);
   let presenting = $state(false);
+  // Split mode (#19): editor + live preview side by side. Both Split and Edit
+  // are "editing" states (activeTab.isEditing true); splitMode just adds the
+  // preview pane, so save / dirty / editContent all keep working unchanged.
+  let splitMode = $state(false);
+  let splitPreviewHtml = $state("");
+  let splitPreviewTimer: ReturnType<typeof setTimeout> | undefined;
   let contentMaxWidth = $derived(getContentMaxWidth($settings));
 
   // Lightbox state
@@ -165,6 +171,26 @@
   let currentMode = $derived<ViewMode>(
     activeTab?.isEditing ? "editor" : rawMode ? "raw" : "viewer"
   );
+  // Which segment of the View/Split/Edit control is active.
+  let activeEditMode = $derived<"view" | "split" | "edit">(
+    activeTab?.isEditing ? (splitMode ? "split" : "edit") : "view"
+  );
+
+  // Live-render the editor content into the split preview pane, debounced so
+  // fast typing stays smooth. ponytail: full re-render per debounce tick; fine
+  // for typical docs — add incremental rendering only if a huge file lags.
+  $effect(() => {
+    if (!splitMode || !activeTab?.isEditing) return;
+    const content = activeTab.editContent;
+    const baseDir = getBaseDir(activeTab.filePath);
+    clearTimeout(splitPreviewTimer);
+    splitPreviewTimer = setTimeout(() => {
+      const result = renderFull(content, baseDir);
+      allowAssets(result.assetPaths);
+      splitPreviewHtml = result.html;
+    }, 120);
+    return () => clearTimeout(splitPreviewTimer);
+  });
 
   // Marp presentation (#44). `presenting` is a page-level view mode (like rawMode);
   // it's only meaningful when the active doc is a Marp deck.
@@ -176,8 +202,9 @@
   function togglePresent() {
     presenting = !presenting;
     if (presenting) {
-      // Entering the slideshow supersedes raw/edit.
+      // Entering the slideshow supersedes raw/edit/split.
       rawMode = false;
+      splitMode = false;
       if (activeTab?.isEditing) tabStore.setEditing(activeTab.id, false);
     }
   }
@@ -230,6 +257,7 @@
       }
       if (activeTab.isEditing) tabStore.setEditing(activeTab.id, false);
       rawMode = target === "raw";
+      splitMode = false; // leaving editing always leaves split
     }
 
     // Scroll the destination after it renders. Two rAFs are needed for the
@@ -349,14 +377,30 @@
     return EXECUTABLE_EXTENSIONS.has(name.slice(dot + 1).toLowerCase());
   }
 
-  function handleEditToggle() {
-    if (!canEditActive || !activeTab) return;
-    if (activeTab.isEditing) {
-      // Exiting edit — go back to whichever non-edit mode was active before
+  // View / Split / Edit segmented control (#19). Split & Edit are both editing
+  // states; splitMode is the only difference. Routed through switchMode so the
+  // source-line position is preserved across the change.
+  function setMode(target: "view" | "split" | "edit") {
+    if (!activeTab) return;
+    if (target === "view") {
+      splitMode = false;
       switchMode(rawMode ? "raw" : "viewer");
+      return;
+    }
+    if (!canEditActive) return;
+    if (target === "edit") {
+      splitMode = false;
+      switchMode("editor");
     } else {
       switchMode("editor");
+      splitMode = true;
     }
+  }
+
+  function handleEditToggle() {
+    if (!canEditActive || !activeTab) return;
+    // Cmd+E toggles full Edit against View (never Split).
+    setMode(activeTab.isEditing ? "view" : "edit");
   }
 
   function handleRawToggle() {
@@ -904,6 +948,7 @@
     if (!id || id === HOME_TAB_ID) {
       rawMode = false;
       presenting = false;
+      splitMode = false;
       docStore.set({
         filePath: null,
         fileName: null,
@@ -975,7 +1020,8 @@
       isEditing={activeTab?.isEditing ?? false}
       dirty={activeTab?.dirty ?? false}
       canEdit={canEditActive}
-      onEditToggle={handleEditToggle}
+      editMode={activeEditMode}
+      onSetMode={setMode}
       onSave={() => activeTab && handleSave(activeTab)}
       onOpenSettings={() => (settingsVisible = true)}
       canPresent={activeIsMarp}
@@ -1022,6 +1068,26 @@
         onExit={() => (presenting = false)}
         onLocalLink={handleLocalLink}
       />
+    {:else if activeTab?.isEditing && splitMode}
+      <!-- Split (#19): editor left, live preview right. Both panes are fixed
+           half-width; the Editor's own fixed positioning takes the `split` prop
+           to yield the left half. -->
+      <Editor
+        value={activeTab.editContent}
+        onChange={(v) => tabStore.updateEditContent(activeTab!.id, v)}
+        fontSize={$settings.fontSize}
+        lineHeight={$settings.lineHeight}
+        maxWidth="100%"
+        showLineNumbers={$settings.showLineNumbers}
+        split
+      />
+      <main class="split-preview">
+        <MarkdownRenderer
+          html={splitPreviewHtml}
+          onImageClick={(src, all, idx) => { lightboxImages = all; lightboxIndex = idx; lightboxVisible = true; }}
+          onLocalLink={handleLocalLink}
+        />
+      </main>
     {:else if activeTab?.isEditing}
       <Editor
         value={activeTab.editContent}
@@ -1110,6 +1176,24 @@
   .content-main {
     padding-bottom: 4rem;
     transition: padding-left 0.15s ease;
+  }
+
+  /* Split preview pane (#19): fixed right half, mirroring the editor's fixed
+     left half. Scrolls independently. Sits below the toolbar+tabbar (75px). */
+  .split-preview {
+    position: fixed;
+    top: 75px;
+    right: 0;
+    left: 50%;
+    bottom: 0;
+    overflow-y: auto;
+    padding-bottom: 4rem;
+    z-index: 1;
+    background: #fafafa;
+  }
+
+  :global(html.dark) .split-preview {
+    background: #161618;
   }
 
   .content-main.toc-spaced {


### PR DESCRIPTION
Addresses the split-pane editing request from #19.

## What

Replaces the single edit-pencil toggle with a **centered `View · Split · Edit` segmented control**, and adds a **Split** mode: editor on the left, live-updating rendered preview on the right.

- **View** → rendered viewer (the separate Raw-source `Cmd+U` toggle still swaps source within it)
- **Split** → editor + live preview side by side
- **Edit** → full-width editor (unchanged; `Cmd+E` still toggles this)

## How

- Split and Edit are both editing states (`activeTab.isEditing`); `splitMode` only adds the preview pane, so **save / dirty / `editContent` / line numbers all keep working**. The preview re-renders `editContent` on a 120ms debounce.
- The Editor's fixed layout takes a `split` prop for the left half; the preview is a fixed right-half pane that scrolls independently.
- The segmented control is **absolutely centered** in the toolbar (anchored to the sticky header) so it stays put regardless of the side groups' widths.
- Entering present / raw / viewer, or switching to the home tab, all leave Split cleanly; `Cmd+E` toggles full Edit (never Split).

## Scope

- Split scroll is **independent** per pane (no editor↔preview sync). One-way sync was prototyped and set aside — it can be a follow-up.
- Non-local tabs (`paste://` / `url://`) disable Split & Edit with an explaining tooltip.

## Testing

`pnpm check` clean (no new errors). Verified in `pnpm tauri dev` on macOS:

- [x] Segmented control centered in the toolbar; active segment highlighted
- [x] Split shows editor + live preview; typing on the left updates the right
- [x] `Cmd+S` / dirty dot / line numbers all work in Split
- [x] Non-local tabs grey out Split & Edit; Raw button still works
- [x] Light + dark