### PR TITLE
feat: open local files via mdhero:// URI scheme (#60)

### DIFF
--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -25,6 +25,17 @@
       </array>
     </dict>
   </array>
+  <key>CFBundleURLTypes</key>
+  <array>
+    <dict>
+      <key>CFBundleURLName</key>
+      <string>com.mdhero.app</string>
+      <key>CFBundleURLSchemes</key>
+      <array>
+        <string>mdhero</string>
+      </array>
+    </dict>
+  </array>
   <key>UTImportedTypeDeclarations</key>
   <array>
     <dict>

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -27,6 +27,44 @@ fn get_opened_files(state: tauri::State<'_, OpenedFiles>) -> Vec<String> {
     result
 }
 
+/// Parse a `mdhero://open?path=<url-encoded-abs-path>` deep link into an
+/// absolute markdown file path. Returns None for any other action, a relative
+/// path, a non-markdown extension, or a file that doesn't exist — the scheme is
+/// a door any webpage can knock on, so we validate strictly before opening. The
+/// path only ever routes to `openFile` (read + render), never a write or exec.
+#[cfg(target_os = "macos")]
+fn parse_mdhero_url(url: &tauri::Url) -> Option<String> {
+    // Action lives in the authority slot: mdhero://open?path=...
+    if url.host_str() != Some("open") {
+        return None;
+    }
+    // query_pairs() percent-decodes once. ponytail: it also maps `+`→space
+    // (form-urlencoding); paths with a literal `+` should encode it as %2B.
+    let raw = url
+        .query_pairs()
+        .find(|(k, _)| k == "path")
+        .map(|(_, v)| v.into_owned())?;
+
+    let expanded = match raw.strip_prefix("~/") {
+        Some(rest) => format!("{}/{}", std::env::var("HOME").ok()?, rest),
+        None => raw,
+    };
+
+    let path = std::path::Path::new(&expanded);
+    let is_md = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.to_ascii_lowercase())
+        .map(|e| matches!(e.as_str(), "md" | "markdown" | "mdown" | "mkd"))
+        .unwrap_or(false);
+
+    if path.is_absolute() && is_md && path.exists() {
+        Some(expanded)
+    } else {
+        None
+    }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
@@ -122,12 +160,16 @@ pub fn run() {
                 let mut file_paths: Vec<String> = Vec::new();
 
                 for url in urls {
-                    let path = if url.scheme() == "file" {
-                        url.to_file_path()
+                    // "Open With" / double-click deliver a file: URL; the
+                    // mdhero:// scheme (#60) delivers a link to parse. Unknown
+                    // schemes are dropped (openFile can't do anything with them).
+                    let path = match url.scheme() {
+                        "file" => url
+                            .to_file_path()
                             .ok()
-                            .map(|p| p.to_string_lossy().to_string())
-                    } else {
-                        Some(url.to_string())
+                            .map(|p| p.to_string_lossy().to_string()),
+                        "mdhero" => parse_mdhero_url(&url),
+                        _ => None,
                     };
 
                     if let Some(p) = path {
@@ -158,4 +200,70 @@ pub fn run() {
                 }
             }
         });
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod tests {
+    use super::parse_mdhero_url;
+    use tauri::Url;
+
+    fn u(s: &str) -> Url {
+        Url::parse(s).unwrap()
+    }
+
+    #[test]
+    fn parses_valid_open_url_with_encoded_space() {
+        let file = std::env::temp_dir().join("mdhero deep link.md");
+        std::fs::write(&file, "# hi").unwrap();
+        let enc = format!(
+            "mdhero://open?path={}",
+            file.to_string_lossy().replace(' ', "%20")
+        );
+        assert_eq!(
+            parse_mdhero_url(&u(&enc)),
+            Some(file.to_string_lossy().to_string())
+        );
+        std::fs::remove_file(&file).ok();
+    }
+
+    #[test]
+    fn expands_tilde() {
+        let home = std::env::var("HOME").unwrap();
+        let file = std::path::Path::new(&home).join("mdhero_tilde_test.md");
+        std::fs::write(&file, "x").unwrap();
+        assert_eq!(
+            parse_mdhero_url(&u("mdhero://open?path=~/mdhero_tilde_test.md")),
+            Some(file.to_string_lossy().to_string())
+        );
+        std::fs::remove_file(&file).ok();
+    }
+
+    #[test]
+    fn rejects_wrong_action() {
+        assert_eq!(parse_mdhero_url(&u("mdhero://delete?path=/tmp/x.md")), None);
+    }
+
+    #[test]
+    fn rejects_non_markdown_extension() {
+        // /etc/passwd exists but isn't markdown → refused before any open.
+        assert_eq!(parse_mdhero_url(&u("mdhero://open?path=/etc/passwd")), None);
+    }
+
+    #[test]
+    fn rejects_relative_path() {
+        assert_eq!(parse_mdhero_url(&u("mdhero://open?path=notes.md")), None);
+    }
+
+    #[test]
+    fn rejects_missing_file() {
+        assert_eq!(
+            parse_mdhero_url(&u("mdhero://open?path=/tmp/does-not-exist-abc.md")),
+            None
+        );
+    }
+
+    #[test]
+    fn rejects_missing_path_param() {
+        assert_eq!(parse_mdhero_url(&u("mdhero://open")), None);
+    }
 }


### PR DESCRIPTION
Closes #60.

Registers a custom `mdhero://` URI scheme so a link can hand a local markdown file to MDHero from anywhere — a tool-generated report can link straight to the files it produced instead of forcing a Finder detour.

```
mdhero://open?path=/Users/me/docs/plan.md
```

Clicking it opens the file in a tab. App closed → launches then opens. File already open → switches to that tab instead of duplicating. The path is URL-encoded so spaces/unicode survive, and a leading `~` expands to `$HOME`.

## Approach

macOS-first, **zero new dependencies**:

- The scheme is declared via `CFBundleURLTypes` in `Info.plist` — the same bundle mechanism that already powers "Open With" (`CFBundleDocumentTypes`).
- The URL arrives through the existing `RunEvent::Opened` handler, so no deep-link plugin or runtime plumbing.
- `parse_mdhero_url` validates strictly before anything opens: action must be `open`, path must be absolute + a markdown extension (`.md`/`.markdown`/`.mdown`/`.mkd`) + exist, decoded exactly once. A registered scheme is reachable from any web page, so the input is gated even though the path only ever routes to `openFile` (read + render) — never a write or exec.
- Already-open files reuse their tab via the existing dedup; no new tab logic.

## Tests

7 Rust unit tests for `parse_mdhero_url`: valid + encoded space, `~` expansion, wrong action, non-markdown extension, relative path, missing file, missing `path` param. Manually verified end-to-end on a signed build: link while running / already-open (dedup) / bad path (no-op) — all correct.

## Deferred (follow-ups)

- **Windows/Linux** — needs `tauri-plugin-deep-link` (install-time registry) + `tauri-plugin-single-instance` (forward into the live instance), and a Windows box to verify.
- `newtab=1` and a folder-into-pinned param — both marked optional by the reporter.