### PR TITLE
feat: start a new empty markdown document (#63)

### DIFF
--- a/src/lib/components/EmptyState.svelte
+++ b/src/lib/components/EmptyState.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { invoke } from "@tauri-apps/api/core";
   import { open } from "@tauri-apps/plugin-dialog";
-  import { openFileDialog, openFile } from "../tauri/files";
+  import { openFileDialog, openFile, newDocument } from "../tauri/files";
   import { recentFiles, clearRecentFiles } from "../stores/recents";
   import { pinnedFolders } from "../stores/pinned";
   import { settings } from "../stores/settings";
@@ -140,7 +140,11 @@
 
   <!-- Quick actions -->
   <div class="quick-actions">
-    <button class="qa-btn qa-primary" onclick={openFileDialog}>
+    <button class="qa-btn qa-primary" onclick={newDocument}>
+      <svg width="15" height="15" viewBox="0 0 15 15" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 1.5h6l3 3v9H3V1.5z"/><line x1="7.5" y1="6" x2="7.5" y2="11"/><line x1="5" y1="8.5" x2="10" y2="8.5"/></svg>
+      New Document
+    </button>
+    <button class="qa-btn" onclick={openFileDialog}>
       <svg width="15" height="15" viewBox="0 0 15 15" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"><path d="M1.5 5l3-2.5h9v10H1.5V5z"/><line x1="1.5" y1="5" x2="4.5" y2="5"/></svg>
       Browse Files
     </button>

--- a/src/lib/components/TabBar.svelte
+++ b/src/lib/components/TabBar.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { tabStore, HOME_TAB_ID, type Tab } from "$lib/stores/tabs";
+  import { newDocument } from "$lib/tauri/files";
   import { copyPath } from "$lib/utils/clipboard";
 
   let {
@@ -76,13 +77,16 @@
   }
 
   function handleNewTab() {
-    tabStore.goHome();
+    newDocument();
   }
 
-  // A tab backed by a real file has a canonical absolute path to copy; paste://
-  // and url:// tabs don't (mirrors +page.svelte's canEditActive gate).
+  // A tab backed by a real file has a canonical absolute path to copy; paste://,
+  // url://, and not-yet-saved new:// tabs don't.
   function isFileTab(tab: Tab): boolean {
-    return !!tab.filePath && !tab.filePath.startsWith("paste://") && !tab.filePath.startsWith("url://");
+    return !!tab.filePath
+      && !tab.filePath.startsWith("paste://")
+      && !tab.filePath.startsWith("url://")
+      && !tab.filePath.startsWith("new://");
   }
 
   function handleContextMenu(e: MouseEvent, tab: Tab) {

--- a/src/lib/stores/tabs.ts
+++ b/src/lib/stores/tabs.ts
@@ -183,6 +183,14 @@ function createTabStore() {
     return t?.lastSavedAt ?? 0;
   }
 
+  // Re-point a tab at a real filesystem path + name. Used when an unsaved
+  // `new://` document gets a location on its first save (#63).
+  function rebindPath(id: string, filePath: string, fileName: string) {
+    tabs.update((ts) =>
+      ts.map((t) => (t.id === id ? { ...t, filePath, fileName } : t))
+    );
+  }
+
   return {
     tabs,
     activeTabId,
@@ -197,6 +205,7 @@ function createTabStore() {
     updateEditContent,
     markSaved,
     getLastSavedAt,
+    rebindPath,
     saveScrollPosition,
   };
 }

--- a/src/lib/tauri/files.ts
+++ b/src/lib/tauri/files.ts
@@ -1,5 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
-import { open } from "@tauri-apps/plugin-dialog";
+import { open, save } from "@tauri-apps/plugin-dialog";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { document } from "../stores/document";
 import { tabStore } from "../stores/tabs";
@@ -70,6 +70,51 @@ export async function openFile(path: string): Promise<void> {
       error: `Failed to open file: ${err}`,
     });
   }
+}
+
+let newDocCounter = 0;
+
+/**
+ * Start a fresh, unsaved markdown document in a new tab, opened straight into
+ * the editor — the "new tab" behavior the UI already advertised (#63). It has
+ * no filesystem path yet (a `new://` sentinel, like `paste://`); the location
+ * is chosen on the first save via `saveAsNewDocument`. The watcher and
+ * copy-path/link resolution skip `new://` tabs until they're saved.
+ */
+export function newDocument(): void {
+  const filePath = `new://${Date.now()}-${newDocCounter++}`;
+  const result = renderFull("");
+  const tabId = tabStore.addTab(
+    filePath,
+    "Untitled",
+    "",
+    result.html,
+    result.frontmatter,
+    result.wordCount
+  );
+  tabStore.setEditing(tabId, true);
+}
+
+/**
+ * First-save flow for a `new://` document: prompt for a location, write the
+ * content, then re-point the tab at the chosen real path (watch + recents +
+ * title). Returns the chosen absolute path, or null if the user cancelled the
+ * dialog (caller should leave the tab dirty and in the editor).
+ */
+export async function saveAsNewDocument(tabId: string, content: string): Promise<string | null> {
+  const chosen = await save({
+    defaultPath: "Untitled.md",
+    filters: [{ name: "Markdown", extensions: ["md", "markdown", "mdown", "mkd"] }],
+  });
+  if (!chosen) return null;
+
+  const fileName = chosen.split("/").pop() ?? chosen;
+  await saveFile(chosen, content);
+  tabStore.rebindPath(tabId, chosen, fileName);
+  addRecentFile(chosen, fileName);
+  getCurrentWindow().setTitle(`${fileName} — MDHero`).catch(() => {});
+  invoke("start_watching", { path: chosen }).catch(() => {});
+  return chosen;
 }
 
 export async function openFileDialog(): Promise<void> {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,10 +6,12 @@
   import {
     allowAssets,
     getBaseDir,
+    newDocument,
     openFile,
     openFileDialog,
     openWithSystem,
     pathExists,
+    saveAsNewDocument,
     saveFile,
   } from "$lib/tauri/files";
   import { showToast } from "$lib/stores/toast";
@@ -273,13 +275,24 @@
   async function handleSave(tab: Tab) {
     if (!tab.dirty) return;
     try {
-      await saveFile(tab.filePath, tab.editContent);
-      const baseDir = getBaseDir(tab.filePath);
+      let targetPath = tab.filePath;
+      let targetName = tab.fileName;
+      // An unsaved `new://` document has no location yet — prompt for one on
+      // this first save, which rebinds the tab to the chosen real path (#63).
+      if (tab.filePath.startsWith("new://")) {
+        const saved = await saveAsNewDocument(tab.id, tab.editContent);
+        if (!saved) return; // cancelled — keep editing, stays dirty
+        targetPath = saved;
+        targetName = saved.split("/").pop() ?? saved;
+      } else {
+        await saveFile(tab.filePath, tab.editContent);
+      }
+      const baseDir = getBaseDir(targetPath);
       const result = renderFull(tab.editContent, baseDir);
       await allowAssets(result.assetPaths);
       tabStore.markSaved(tab.id);
       tabStore.updateTabContent(
-        tab.filePath,
+        targetPath,
         tab.editContent,
         result.html,
         result.frontmatter,
@@ -289,8 +302,8 @@
       // when the user toggles out of edit mode (the tab-sync $effect only fires on
       // active-tab change, not on content updates of the same tab).
       docStore.set({
-        filePath: tab.filePath,
-        fileName: tab.fileName,
+        filePath: targetPath,
+        fileName: targetName,
         content: tab.editContent,
         renderedHtml: result.html,
         frontmatter: result.frontmatter,
@@ -314,7 +327,7 @@
     const tab = activeTab;
     // paste:// and url:// tabs have no real base dir to resolve against — keep
     // the prior external-opener behavior for their links.
-    if (!tab || !tab.filePath || tab.filePath.startsWith("paste://") || tab.filePath.startsWith("url://")) {
+    if (!tab || !tab.filePath || tab.filePath.startsWith("paste://") || tab.filePath.startsWith("url://") || tab.filePath.startsWith("new://")) {
       try {
         const { openUrl } = await import("@tauri-apps/plugin-opener");
         await openUrl(href);
@@ -797,10 +810,10 @@
       return;
     }
 
-    // Cmd+T new tab (go home)
+    // Cmd+T new document (blank tab, opens in the editor — #63)
     if ((e.metaKey || e.ctrlKey) && e.key === "t") {
       e.preventDefault();
-      tabStore.goHome();
+      newDocument();
       return;
     }
 
@@ -1001,7 +1014,7 @@
   // Watch for file path changes to set up watcher (only when path actually changes)
   $effect(() => {
     const path = $docStore.filePath;
-    if (path && !path.startsWith("paste://") && path !== lastWatchedPath) {
+    if (path && !path.startsWith("paste://") && !path.startsWith("new://") && path !== lastWatchedPath) {
       lastWatchedPath = path;
       startFileWatcher(path);
     }


### PR DESCRIPTION
Closes #63.

## What
Adds a way to start a brand-new empty markdown document — the behavior the UI already advertised. Previously `Cmd+T`, the tab-bar `+` button, and the (absent) "New" affordance all just went to the home screen, so `Cmd+T` appeared to do nothing.

Now all three open a **blank tab straight in the editor**, and there's a **New Document** button on the home screen.

## How
- New tabs are pathless — a `new://` sentinel, same shape as the existing `paste://`/`url://` tabs.
- Location is chosen on the **first `Cmd+S`** via a save dialog, which rebinds the tab to the real path, adds it to recents, sets the title, and starts watching.
- The file watcher, copy-path, and local-link resolution skip `new://` tabs until they're saved.
- Reuses the existing #52 empty-file-into-editor behavior and the own-save reload suppression, so no phantom reload after the first save.

## Files
- `files.ts` — `newDocument()` + `saveAsNewDocument()` (first-save dialog + rebind)
- `tabs.ts` — `rebindPath()` so an untitled tab adopts its real path
- `+page.svelte` — `Cmd+T` → new doc; save-as branch in `handleSave`; watcher + link-resolver skip `new://`
- `TabBar.svelte` — `+` creates a new doc; copy-path/context-menu excluded for unsaved tabs
- `EmptyState.svelte` — "New Document" button (now the primary home action)

Backend (`lib.rs`) is untouched — pure frontend.

## Test
- `Cmd+T` / `+` / "New Document" → blank editor, type immediately
- Type → `Cmd+S` → save dialog → afterwards a normal watched file (re-save is silent, no reload)
- Unsaved new tab → close → existing unsaved-changes prompt catches it
- `pnpm check` clean on changed files (3 pre-existing errors unrelated)