### PR TITLE
Fix live reload after switching tabs

### DIFF
--- a/src/lib/tauri/files.ts
+++ b/src/lib/tauri/files.ts
@@ -57,7 +57,6 @@ export async function openFile(path: string): Promise<void> {
 
     addRecentFile(absolutePath, fileName);
     getCurrentWindow().setTitle(`${fileName} — MDHero`).catch(() => {});
-    invoke("start_watching", { path: absolutePath }).catch(() => {});
   } catch (err) {
     document.set({
       filePath: absolutePath,
@@ -113,7 +112,6 @@ export async function saveAsNewDocument(tabId: string, content: string): Promise
   tabStore.rebindPath(tabId, chosen, fileName);
   addRecentFile(chosen, fileName);
   getCurrentWindow().setTitle(`${fileName} — MDHero`).catch(() => {});
-  invoke("start_watching", { path: chosen }).catch(() => {});
   return chosen;
 }
 

--- a/src/lib/tauri/watcher.ts
+++ b/src/lib/tauri/watcher.ts
@@ -1,4 +1,5 @@
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { invoke } from "@tauri-apps/api/core";
 import { reloadCurrentFile } from "./files";
 import { tabStore } from "../stores/tabs";
 
@@ -24,6 +25,10 @@ export async function startFileWatcher(filePath: string): Promise<void> {
       reloadCurrentFile(filePath);
     }, 100);
   });
+
+  // The Rust watcher tracks only one file. Re-start it whenever the active
+  // tab changes so returning to a previously opened tab watches its file again.
+  invoke("start_watching", { path: filePath }).catch(() => {});
 }
 
 export function stopFileWatcher(): void {

--- a/tests/unit/watcher.test.ts
+++ b/tests/unit/watcher.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const listen = vi.fn();
+const invoke = vi.fn();
+const reloadCurrentFile = vi.fn();
+
+vi.mock("@tauri-apps/api/event", () => ({ listen }));
+vi.mock("@tauri-apps/api/core", () => ({ invoke }));
+vi.mock("../../src/lib/tauri/files", () => ({ reloadCurrentFile }));
+vi.mock("../../src/lib/stores/tabs", () => ({
+  tabStore: { getLastSavedAt: vi.fn(() => 0) },
+}));
+
+const { startFileWatcher, stopFileWatcher } = await import("../../src/lib/tauri/watcher");
+
+describe("file watcher", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    listen.mockResolvedValue(vi.fn());
+    invoke.mockResolvedValue(undefined);
+    stopFileWatcher();
+  });
+
+  it("restarts the backend watcher when switching between file tabs", async () => {
+    await startFileWatcher("C:/docs/a.md");
+    await startFileWatcher("C:/docs/b.md");
+    await startFileWatcher("C:/docs/a.md");
+
+    expect(invoke).toHaveBeenNthCalledWith(1, "start_watching", { path: "C:/docs/a.md" });
+    expect(invoke).toHaveBeenNthCalledWith(2, "start_watching", { path: "C:/docs/b.md" });
+    expect(invoke).toHaveBeenNthCalledWith(3, "start_watching", { path: "C:/docs/a.md" });
+    expect(invoke).toHaveBeenCalledTimes(3);
+    expect(listen).toHaveBeenCalledTimes(3);
+  });
+
+  it("unsubscribes the previous event listener when switching files", async () => {
+    const firstUnlisten = vi.fn();
+    listen.mockResolvedValueOnce(firstUnlisten).mockResolvedValueOnce(vi.fn());
+
+    await startFileWatcher("C:/docs/a.md");
+    await startFileWatcher("C:/docs/b.md");
+
+    expect(firstUnlisten).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes live-reload detection after switching between open file tabs.

Fixes #68

## Changes

- Restart the Rust-side watcher whenever the active tab's file changes.
- Centralize watcher startup in `startFileWatcher`.
- Remove duplicate watcher-start calls from file-opening flows.
- Add regression tests for switching A → B → A and listener cleanup.

## Testing

- [x] Tested in dev mode (`pnpm tauri dev`).
- [x] Verified in light mode.
- [x] Verified in dark mode.
- [x] Verified live reload after switching between multiple tabs.
- [x] Existing automated tests pass — 34 tests across 4 files.
- [ ] `pnpm run check` passes.

Note: `pnpm run check` reports 3 pre-existing type errors unrelated to this PR.