### PR TITLE
ci: add linux release builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,8 @@ jobs:
             libxdo-dev \
             libssl-dev \
             libayatana-appindicator3-dev \
-            librsvg2-dev
+            librsvg2-dev \
+            xdg-utils
 
       - name: Install frontend dependencies
         run: pnpm install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,8 @@ jobs:
             name: macOS
           - platform: windows-latest
             name: Windows
+          - platform: ubuntu-22.04
+            name: Linux
 
     runs-on: ${{ matrix.platform }}
 
@@ -41,6 +43,21 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri -> target
+      
+      - name: Install Linux dependencies
+        if: matrix.platform == 'ubuntu-22.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            build-essential \
+            curl \
+            wget \
+            file \
+            libxdo-dev \
+            libssl-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev
 
       - name: Install frontend dependencies
         run: pnpm install
@@ -142,4 +159,7 @@ jobs:
             src-tauri/target/release/bundle/macos/*.app
             src-tauri/target/release/bundle/msi/*.msi
             src-tauri/target/release/bundle/nsis/*.exe
+            src-tauri/target/release/bundle/deb/*.deb
+            src-tauri/target/release/bundle/rpm/*.rpm
+            src-tauri/target/release/bundle/appimage/*.AppImage
           if-no-files-found: ignore


### PR DESCRIPTION
## Summary

Adds Linux builds and release artifacts to the existing CI workflow.

## Changes

* Added `ubuntu-22.04` to the build matrix
* Added the required Linux dependencies for Tauri
* Added `.deb`, `.rpm`, and `.AppImage` to uploaded artifacts

## Testing

* [ ] Tested in dev mode (`pnpm tauri dev`)
* [ ] Works in both light and dark mode
* [x] No regressions in existing features
* [ ] `pnpm check` passes

Also verified the Linux build locally with `act` using the ubuntu-22.04 runner setup.