### PR TITLE
Add windows 11 arm builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,8 @@ jobs:
             name: macOS
           - platform: windows-latest
             name: Windows
+          - platform: windows-11-arm
+            name: Windows 11 ARM
           - platform: ubuntu-22.04
             name: Linux
 


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Keep it brief. -->

Add windows 11 arm builds and release artifacts

## Changes

<!-- Bullet list of specific changes -->

- Add `windows-11-arm` to the build platform matrix

## Testing

<!-- How did you verify this works? -->

- [ ] Tested in dev mode (`pnpm tauri dev`)
- [ ] Works in both light and dark mode
- [x] No regressions in existing features
- [ ] `pnpm check` passes

I personally doesnt have arm based laptops, i cant test it, so i treat this opinionated