### PR TITLE
Add linux arm64 builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,8 @@ jobs:
             name: Windows
           - platform: ubuntu-22.04
             name: Linux
+          - platform: ubuntu-22.04-arm
+            name: Linux arm64
 
     runs-on: ${{ matrix.platform }}
 
@@ -45,7 +47,7 @@ jobs:
           workspaces: src-tauri -> target
       
       - name: Install Linux dependencies
-        if: matrix.platform == 'ubuntu-22.04'
+        if: startsWith(matrix.platform, 'ubuntu-')
         run: |
           sudo apt-get update
           sudo apt-get install -y \


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Keep it brief. -->

https://github.com/vaibhav-kakde-in/mdhero/pull/75

Adding arm64 with `ubuntu-22.04-arm` runner on top of it

## Changes

<!-- Bullet list of specific changes -->

-

## Testing

<!-- How did you verify this works? -->

- [ ] Tested in dev mode (`pnpm tauri dev`)
- [ ] Works in both light and dark mode
- [x] No regressions in existing features
- [ ] `pnpm check` passes
