### PR TITLE
fix: cover every highlight.js token class in dark mode (#67)

### DIFF
--- a/src/lib/components/MarkdownRenderer.svelte
+++ b/src/lib/components/MarkdownRenderer.svelte
@@ -555,26 +555,80 @@
     box-shadow: 0 2px 8px rgba(0,0,0,0.3);
   }
 
-  /* Code block dark mode override for highlight.js */
+  /* Code block dark mode override for highlight.js.
+   *
+   * This mirrors highlight.js's own `github-dark` theme, selector group for
+   * selector group, against the `github` (light) theme imported in app.css.
+   * It deliberately covers EVERY class the light theme colours — not a
+   * hand-picked subset.
+   *
+   * The subset approach was the bug in #67: any class the light theme styled
+   * but the dark override missed kept its light colour against #0d1117.
+   * `.hljs-subst`, `.hljs-emphasis` and `.hljs-strong` are #24292e — near-black
+   * on a near-black background, i.e. invisible — and `.hljs-bullet` (#735c0f),
+   * `.hljs-literal`/`.hljs-operator` (#005cc5) and friends were barely legible.
+   * Fixing only the tokens in the bug report would have left the rest invisible.
+   *
+   * Source: node_modules/highlight.js/styles/github-dark.min.css
+   * `tests/unit/hljs-dark-coverage.test.ts` fails if the two ever drift apart,
+   * so a highlight.js upgrade that adds a class can't silently reintroduce this.
+   */
   :global(html.dark) article :global(pre) {
     background: #0d1117 !important;
-    color: #e6edf3 !important;
+    color: #c9d1d9 !important;
   }
+  :global(html.dark) article :global(.hljs) { color: #c9d1d9 !important; background: #0d1117 !important; }
 
-  :global(html.dark) article :global(.hljs-keyword) { color: #ff7b72 !important; }
+  :global(html.dark) article :global(.hljs-doctag),
+  :global(html.dark) article :global(.hljs-keyword),
+  :global(html.dark) article :global(.hljs-meta .hljs-keyword),
+  :global(html.dark) article :global(.hljs-template-tag),
+  :global(html.dark) article :global(.hljs-template-variable),
+  :global(html.dark) article :global(.hljs-type),
+  :global(html.dark) article :global(.hljs-variable.language_) { color: #ff7b72 !important; }
+
+  :global(html.dark) article :global(.hljs-title),
+  :global(html.dark) article :global(.hljs-title.class_),
+  :global(html.dark) article :global(.hljs-title.class_.inherited__),
+  :global(html.dark) article :global(.hljs-title.function_) { color: #d2a8ff !important; }
+
+  :global(html.dark) article :global(.hljs-attr),
+  :global(html.dark) article :global(.hljs-attribute),
+  :global(html.dark) article :global(.hljs-literal),
+  :global(html.dark) article :global(.hljs-meta),
+  :global(html.dark) article :global(.hljs-number),
+  :global(html.dark) article :global(.hljs-operator),
+  :global(html.dark) article :global(.hljs-selector-attr),
+  :global(html.dark) article :global(.hljs-selector-class),
+  :global(html.dark) article :global(.hljs-selector-id),
+  :global(html.dark) article :global(.hljs-variable) { color: #79c0ff !important; }
+
+  :global(html.dark) article :global(.hljs-meta .hljs-string),
+  :global(html.dark) article :global(.hljs-regexp),
   :global(html.dark) article :global(.hljs-string) { color: #a5d6ff !important; }
-  :global(html.dark) article :global(.hljs-comment) { color: #8b949e !important; }
-  :global(html.dark) article :global(.hljs-number) { color: #79c0ff !important; }
-  :global(html.dark) article :global(.hljs-function) { color: #d2a8ff !important; }
-  :global(html.dark) article :global(.hljs-title) { color: #d2a8ff !important; }
-  :global(html.dark) article :global(.hljs-built_in) { color: #ffa657 !important; }
-  :global(html.dark) article :global(.hljs-type) { color: #ffa657 !important; }
-  :global(html.dark) article :global(.hljs-attr) { color: #79c0ff !important; }
-  :global(html.dark) article :global(.hljs-variable) { color: #ffa657 !important; }
-  :global(html.dark) article :global(.hljs-params) { color: #e6edf3 !important; }
-  :global(html.dark) article :global(.hljs-meta) { color: #79c0ff !important; }
-  :global(html.dark) article :global(.hljs-addition) { color: #aff5b4 !important; background: rgba(46,160,67,0.15) !important; }
-  :global(html.dark) article :global(.hljs-deletion) { color: #ffdcd7 !important; background: rgba(248,81,73,0.15) !important; }
+
+  :global(html.dark) article :global(.hljs-built_in),
+  :global(html.dark) article :global(.hljs-symbol) { color: #ffa657 !important; }
+
+  :global(html.dark) article :global(.hljs-code),
+  :global(html.dark) article :global(.hljs-comment),
+  :global(html.dark) article :global(.hljs-formula) { color: #8b949e !important; }
+
+  :global(html.dark) article :global(.hljs-name),
+  :global(html.dark) article :global(.hljs-quote),
+  :global(html.dark) article :global(.hljs-selector-pseudo),
+  :global(html.dark) article :global(.hljs-selector-tag) { color: #7ee787 !important; }
+
+  :global(html.dark) article :global(.hljs-subst) { color: #c9d1d9 !important; }
+  /* The one deliberate deviation from upstream github-dark: its #1f6feb scores
+   * 4.08:1 against #0d1117, under the 4.5:1 WCAG AA floor the test enforces.
+   * #58a6ff is GitHub's own dark-mode blue and scores 7.49:1. */
+  :global(html.dark) article :global(.hljs-section) { color: #58a6ff !important; font-weight: 700; }
+  :global(html.dark) article :global(.hljs-bullet) { color: #f2cc60 !important; }
+  :global(html.dark) article :global(.hljs-emphasis) { color: #c9d1d9 !important; font-style: italic; }
+  :global(html.dark) article :global(.hljs-strong) { color: #c9d1d9 !important; font-weight: 700; }
+  :global(html.dark) article :global(.hljs-addition) { color: #aff5b4 !important; background-color: #033a16 !important; }
+  :global(html.dark) article :global(.hljs-deletion) { color: #ffdcd7 !important; background-color: #67060c !important; }
 
   /* Mermaid */
   article :global(.mermaid-diagram) {

--- a/tests/unit/hljs-dark-coverage.test.ts
+++ b/tests/unit/hljs-dark-coverage.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+/**
+ * Regression guard for #67 — dark-mode syntax highlighting.
+ *
+ * The bug: the dark override in MarkdownRenderer.svelte listed only a hand-picked
+ * subset of highlight.js token classes. Every class the light `github` theme
+ * coloured but the dark override missed kept its LIGHT colour against the forced
+ * #0d1117 background. `.hljs-subst` / `.hljs-emphasis` / `.hljs-strong` are
+ * #24292e — a contrast ratio of 1.29:1, i.e. invisible.
+ *
+ * Two independent assertions, because either alone can pass while the bug is live:
+ *   1. Coverage — every class the light theme styles has a dark-mode rule. Catches
+ *      a highlight.js upgrade introducing a class we don't override.
+ *   2. Contrast — every dark-mode text colour clears WCAG AA (4.5:1) against the
+ *      code-block background. Catches a rule that exists but is unreadable, which
+ *      is the actual user-visible defect.
+ */
+
+const require = createRequire(import.meta.url);
+const here = dirname(fileURLToPath(import.meta.url));
+
+const COMPONENT = resolve(here, "../../src/lib/components/MarkdownRenderer.svelte");
+const LIGHT_THEME = require.resolve("highlight.js/styles/github.min.css");
+
+const CODE_BG = "#0d1117";
+const WCAG_AA_NORMAL_TEXT = 4.5;
+
+function relativeLuminance(hex: string): number {
+  const h = hex.replace("#", "");
+  const [r, g, b] = [0, 2, 4].map((i) => parseInt(h.slice(i, i + 2), 16) / 255);
+  const lin = (c: number) => (c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4);
+  return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
+}
+
+function contrastRatio(a: string, b: string): number {
+  const [hi, lo] = [relativeLuminance(a), relativeLuminance(b)].sort((x, y) => y - x);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+/**
+ * Every `hljs-*` class name mentioned in a chunk of CSS.
+ *
+ * The character class must include `-`, or compound names collapse:
+ * `hljs-selector-attr` would truncate to `hljs-selector` and the comparison
+ * would run at a coarser granularity than it appears to, letting a partially
+ * covered group (say `selector-attr` but not `selector-class`) pass.
+ */
+function hljsClasses(css: string): Set<string> {
+  return new Set(css.match(/hljs-[a-zA-Z0-9_-]+/g) ?? []);
+}
+
+/** The component's dark-mode block: from the override comment to the Mermaid section. */
+function darkModeBlock(): string {
+  const source = readFileSync(COMPONENT, "utf8");
+  const start = source.indexOf("/* Code block dark mode override");
+  const end = source.indexOf("/* Mermaid */");
+  expect(start, "dark-mode override block not found in MarkdownRenderer.svelte").toBeGreaterThan(-1);
+  expect(end, "Mermaid section not found — block boundary changed").toBeGreaterThan(start);
+  return source.slice(start, end);
+}
+
+describe("#67 — dark-mode highlight.js coverage", () => {
+  it("overrides every token class the light theme colours", () => {
+    const light = hljsClasses(readFileSync(LIGHT_THEME, "utf8"));
+    const dark = hljsClasses(darkModeBlock());
+
+    // Sanity-check the extraction itself, so a regex that silently matches
+    // nothing can't make this test vacuously pass.
+    expect(light.size).toBeGreaterThan(20);
+
+    const missing = [...light].filter((c) => !dark.has(c)).sort();
+    expect(
+      missing,
+      `these classes are styled by the light theme but have no dark-mode rule, so ` +
+        `they keep their light colour on ${CODE_BG}: ${missing.join(", ")}`
+    ).toEqual([]);
+  });
+
+  it("gives every dark-mode token colour readable contrast on the code background", () => {
+    const block = darkModeBlock();
+
+    // `color:` only. background-color values (.hljs-addition / .hljs-deletion)
+    // are deliberately dark and are not text.
+    const colours = [...block.matchAll(/(?<!background-)color:\s*(#[0-9a-fA-F]{6})/g)].map(
+      (m) => m[1].toLowerCase()
+    );
+    expect(colours.length).toBeGreaterThan(10);
+
+    const failures = [...new Set(colours)]
+      .map((c) => ({ colour: c, ratio: contrastRatio(c, CODE_BG) }))
+      .filter(({ ratio }) => ratio < WCAG_AA_NORMAL_TEXT)
+      .map(({ colour, ratio }) => `${colour} (${ratio.toFixed(2)}:1)`);
+
+    expect(
+      failures,
+      `these dark-mode colours fall below WCAG AA ${WCAG_AA_NORMAL_TEXT}:1 against ` +
+        `${CODE_BG}: ${failures.join(", ")}`
+    ).toEqual([]);
+  });
+
+  it("detects the specific colours that made #67 invisible", () => {
+    // Guards the guard: if these light-theme values ever reappear as dark-mode
+    // text colours, the contrast assertion above must fail. #24292e is the one
+    // from the bug report (.hljs-subst on a near-black background).
+    const leakedLightColours = ["#24292e", "#032f62", "#735c0f"];
+    for (const leaked of leakedLightColours) {
+      expect(contrastRatio(leaked, CODE_BG)).toBeLessThan(WCAG_AA_NORMAL_TEXT);
+    }
+
+    // Match declarations, not raw text — the block's own comment cites #24292e
+    // as the offending value, and that documentation should not fail the test.
+    const declared = [...darkModeBlock().matchAll(/color:\s*(#[0-9a-fA-F]{6})/g)].map((m) =>
+      m[1].toLowerCase()
+    );
+    expect(declared.filter((c) => leakedLightColours.includes(c))).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #67. Dark mode only overrode 14 hand-picked highlight.js classes, so every
class the light `github` theme colours but the override missed kept its **light**
colour against the forced `#0d1117` background.

The reported `1_000_000` case was one instance of a whole class of invisible
tokens — patching just those would have left the rest unreadable:

| class | contrast on `#0d1117` before |
|---|---|
| `.hljs-subst`, `.hljs-emphasis`, `.hljs-strong` | **1.29:1** (invisible) |
| `.hljs-regexp` | 1.43:1 |
| `.hljs-bullet` | 2.94:1 |
| `.hljs-literal`, `.hljs-operator`, `.hljs-section` | 3.01:1 |
| `.hljs-name`, `.hljs-quote` | 4.09:1 |

## Changes

- Replace the allowlist with a full mirror of highlight.js's own `github-dark`
  theme, selector group for selector group, so no class the light theme styles
  can fall through.
- One deliberate deviation from upstream: `.hljs-section` uses `#58a6ff`
  (7.49:1) instead of upstream `#1f6feb` (4.08:1), which fails the WCAG AA floor
  the new test enforces.
- Add `tests/unit/hljs-dark-coverage.test.ts` with three assertions — class
  coverage against the light theme, AA contrast for every dark colour, and a
  guard that the leaked light values never reappear.

**After:** nothing falls below WCAG AA, minimum **6.15:1**; `.hljs-subst` goes
from 1.29:1 to **12.26:1**.

## Testing

- [x] Tested in dev mode (`pnpm tauri dev`)
- [x] Works in both light and dark mode
- [x] No regressions in existing features
- [x] `pnpm check` passes (4 pre-existing errors, unchanged)

Verified by measurement rather than by eye, at two levels:

- **Computed styles** in the browser across all 34 classes, in both themes.
  Dark: 0 below AA (min 6.15:1). Light: unchanged by this PR.
- **Rendered pixels** in the app — the Ruby `#{name}` interpolation went from
  `#2a2d31` @ 1.37:1 to `#cad0d8` @ **12.19:1**.

The new test was confirmed to **fail on the unfixed code**, naming all 22
uncovered classes, so a future highlight.js upgrade that adds a class cannot
silently reintroduce this.

Light mode is untouched. It has its own marginal cases (12 classes at 3.3–4.4:1,
all upstream GitHub values) — a different severity from the 1.29:1 dark case, and
out of scope here rather than widening this into a light-palette redesign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aj5d1MMUcs1zcD7j2zAb2A