### PR TITLE
Fix Windows home directory, file names and canonical paths (#76)

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -48,6 +48,56 @@ pub fn write_markdown_file(path: String, content: String) -> Result<(), String> 
     fs::write(p, content).map_err(|e| format!("Failed to write file: {}", e))
 }
 
+/// The current user's home directory.
+///
+/// `std::env::var("HOME")` is not set on Windows, so every caller that used it
+/// failed there — the "Plans" list was permanently empty on Windows builds.
+/// Kept dependency-free on purpose: `USERPROFILE` (plus the HOMEDRIVE/HOMEPATH
+/// fallback for older/roaming setups) is what Windows actually provides.
+pub fn home_dir() -> Option<std::path::PathBuf> {
+    #[cfg(windows)]
+    {
+        if let Some(profile) = std::env::var_os("USERPROFILE").filter(|s| !s.is_empty()) {
+            return Some(std::path::PathBuf::from(profile));
+        }
+        match (
+            std::env::var_os("HOMEDRIVE").filter(|s| !s.is_empty()),
+            std::env::var_os("HOMEPATH").filter(|s| !s.is_empty()),
+        ) {
+            (Some(drive), Some(rest)) => {
+                let mut joined = std::ffi::OsString::from(drive);
+                joined.push(&rest);
+                Some(std::path::PathBuf::from(joined))
+            }
+            _ => None,
+        }
+    }
+    #[cfg(not(windows))]
+    {
+        std::env::var_os("HOME")
+            .filter(|s| !s.is_empty())
+            .map(std::path::PathBuf::from)
+    }
+}
+
+/// Strip Windows' verbatim prefix (`\\?\`) that `canonicalize` returns.
+///
+/// The prefix is valid but leaks into anything that displays the path, and it
+/// breaks naive string handling on the frontend. `\\?\UNC\server\share` folds
+/// back to `\\server\share`. No-op on other platforms.
+fn strip_verbatim_prefix(path: String) -> String {
+    #[cfg(windows)]
+    {
+        if let Some(rest) = path.strip_prefix(r"\\?\UNC\") {
+            return format!(r"\\{}", rest);
+        }
+        if let Some(rest) = path.strip_prefix(r"\\?\") {
+            return rest.to_string();
+        }
+    }
+    path
+}
+
 #[tauri::command]
 pub fn resolve_path(path: String) -> Result<String, String> {
     let p = Path::new(&path);
@@ -63,7 +113,7 @@ pub fn resolve_path(path: String) -> Result<String, String> {
         .canonicalize()
         .unwrap_or(absolute)
         .to_str()
-        .map(|s| s.to_string())
+        .map(|s| strip_verbatim_prefix(s.to_string()))
         .ok_or_else(|| format!("Path is not valid UTF-8: {}", path))
 }
 
@@ -96,8 +146,8 @@ pub fn allow_assets(app: AppHandle, paths: Vec<String>) -> Result<(), String> {
 
 #[tauri::command]
 pub fn list_claude_plans() -> Result<Vec<PlanFile>, String> {
-    let home = std::env::var("HOME").map_err(|_| "Cannot determine home directory".to_string())?;
-    let plans_dir = Path::new(&home).join(".claude").join("plans");
+    let home = home_dir().ok_or_else(|| "Cannot determine home directory".to_string())?;
+    let plans_dir = home.join(".claude").join("plans");
 
     if !plans_dir.exists() {
         return Ok(Vec::new());
@@ -373,4 +423,25 @@ pub fn show_ai_context_menu(
     window.popup_menu(&menu).map_err(|e| e.to_string())?;
 
     Ok(())
+}
+
+#[cfg(all(test, windows))]
+mod tests {
+    use super::strip_verbatim_prefix;
+
+    #[test]
+    fn strips_the_verbatim_prefix_canonicalize_returns() {
+        assert_eq!(
+            strip_verbatim_prefix(r"\\?\C:\Users\hugo\a.md".to_string()),
+            r"C:\Users\hugo\a.md"
+        );
+        assert_eq!(
+            strip_verbatim_prefix(r"\\?\UNC\server\share\a.md".to_string()),
+            r"\\server\share\a.md"
+        );
+        assert_eq!(
+            strip_verbatim_prefix(r"C:\Users\hugo\a.md".to_string()),
+            r"C:\Users\hugo\a.md"
+        );
+    }
 }

--- a/src/lib/components/EmptyState.svelte
+++ b/src/lib/components/EmptyState.svelte
@@ -6,6 +6,7 @@
   import { pinnedFolders } from "../stores/pinned";
   import { settings } from "../stores/settings";
   import UpdateBanner from "./UpdateBanner.svelte";
+  import { basename, shortenHomePath } from "$lib/utils/path";
   import brandLogo from "$lib/assets/mdhero-icon.png";
 
   let { onOpenUrl = () => {} }: { onOpenUrl?: () => void } = $props();
@@ -73,9 +74,6 @@
     folderFiles = rest;
   }
 
-  function getFolderName(path: string): string {
-    return path.split("/").pop() || path;
-  }
 
   function formatTime(ts: number): string {
     const diff = Date.now() - ts;
@@ -89,15 +87,6 @@
     return new Date(ts).toLocaleDateString();
   }
 
-  function shortenPath(path: string): string {
-    const home = "/Users/";
-    if (path.startsWith(home)) {
-      const rest = path.slice(home.length);
-      const parts = rest.split("/");
-      if (parts.length > 1) return "~/" + parts.slice(1).join("/");
-    }
-    return path;
-  }
 
   function formatPlanName(name: string): string {
     return name.replace(/\.md$/, "").replace(/[-_]/g, " ");
@@ -168,7 +157,7 @@
       <div class="card card-scroll uniform-card">
         <div class="recents-grid" class:two-col={twoCol}>
           {#each $recentFiles as file (file.path)}
-            {@render fileRow(file.name, shortenPath(file.path), formatTime(file.openedAt), () => openFile(file.path), 'file')}
+            {@render fileRow(file.name, shortenHomePath(file.path), formatTime(file.openedAt), () => openFile(file.path), 'file')}
           {/each}
         </div>
       </div>
@@ -200,7 +189,7 @@
           </div>
           <div class="card card-scroll uniform-card">
             {#each plans as plan (plan.path)}
-              {@render fileRow(formatPlanName(plan.name), shortenPath(plan.path), formatTime(plan.modified), () => openFile(plan.path), 'plan')}
+              {@render fileRow(formatPlanName(plan.name), shortenHomePath(plan.path), formatTime(plan.modified), () => openFile(plan.path), 'plan')}
             {/each}
           </div>
         </div>
@@ -211,7 +200,7 @@
           <div class="section-header">
             <h2 class="section-title">
               <svg width="12" height="12" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"><path d="M1.5 4.5l3-2.5h8v9H1.5V4.5z"/><line x1="1.5" y1="4.5" x2="4.5" y2="4.5"/></svg>
-              {getFolderName(folder)}
+              {basename(folder)}
             </h2>
             <span class="section-count">{folderFiles[folder]?.length ?? '...'}</span>
             <button class="section-action unpin" onclick={(e) => removePinnedFolder(e, folder)} title="Unpin">

--- a/src/lib/components/OpenDialog.svelte
+++ b/src/lib/components/OpenDialog.svelte
@@ -8,6 +8,7 @@
   import { renderFull } from "$lib/renderer/pipeline";
   import { tabStore } from "$lib/stores/tabs";
   import { document as docStore } from "$lib/stores/document";
+  import { basename, shortenHomePath } from "$lib/utils/path";
 
   let { visible = $bindable(false) }: { visible: boolean } = $props();
 
@@ -124,15 +125,6 @@
     return new Date(ts).toLocaleDateString();
   }
 
-  function shortenPath(path: string): string {
-    const home = "/Users/";
-    if (path.startsWith(home)) {
-      const rest = path.slice(home.length);
-      const parts = rest.split("/");
-      if (parts.length > 1) return "~/" + parts.slice(1).join("/");
-    }
-    return path;
-  }
 
   function formatPlanName(name: string): string {
     return name.replace(/\.md$/, "").replace(/[-_]/g, " ");
@@ -162,9 +154,6 @@
     } catch {}
   }
 
-  function getFolderName(path: string): string {
-    return path.split("/").pop() || path;
-  }
 
   $effect(() => {
     if (visible && activeTab === "plans") {
@@ -279,7 +268,7 @@
                 </div>
                 <div class="file-info">
                   <span class="file-name">{file.name}</span>
-                  <span class="file-path">{shortenPath(file.path)}</span>
+                  <span class="file-path">{shortenHomePath(file.path)}</span>
                 </div>
                 <span class="file-time">{formatTime(file.openedAt)}</span>
               </button>
@@ -304,9 +293,9 @@
                   <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round">
                     <path d="M1.5 4.5l3-2.5h8v9H1.5V4.5z"/><line x1="1.5" y1="4.5" x2="4.5" y2="4.5"/>
                   </svg>
-                  <span class="folder-name">{getFolderName(folder)}</span>
+                  <span class="folder-name">{basename(folder)}</span>
                   <span class="folder-file-count">{folderFiles[folder]?.length ?? '...'}</span>
-                  <span class="folder-path">{shortenPath(folder)}</span>
+                  <span class="folder-path">{shortenHomePath(folder)}</span>
                 </button>
                 {#if expandedDialogFolders.has(folder)}
                   {#if folderFiles[folder]}
@@ -353,7 +342,7 @@
                 </div>
                 <div class="file-info">
                   <span class="file-name">{formatPlanName(plan.name)}</span>
-                  <span class="file-path">{shortenPath(plan.path)}</span>
+                  <span class="file-path">{shortenHomePath(plan.path)}</span>
                 </div>
                 <span class="file-time">{formatTime(plan.modified)}</span>
               </button>

--- a/src/lib/tauri/files.ts
+++ b/src/lib/tauri/files.ts
@@ -5,6 +5,7 @@ import { document } from "../stores/document";
 import { tabStore } from "../stores/tabs";
 import { renderFull } from "../renderer/pipeline";
 import { addRecentFile } from "../stores/recents";
+import { basename } from "../utils/path";
 
 export async function readMarkdownFile(path: string): Promise<string> {
   return invoke<string>("read_markdown_file", { path });
@@ -16,7 +17,7 @@ export async function saveFile(path: string, content: string): Promise<void> {
 
 export async function openFile(path: string): Promise<void> {
   const absolutePath = await resolvePath(path);
-  const fileName = absolutePath.split("/").pop() ?? absolutePath;
+  const fileName = basename(absolutePath);
   const baseDir = getBaseDir(absolutePath);
 
   document.set({
@@ -107,7 +108,7 @@ export async function saveAsNewDocument(tabId: string, content: string): Promise
   });
   if (!chosen) return null;
 
-  const fileName = chosen.split("/").pop() ?? chosen;
+  const fileName = basename(chosen);
   await saveFile(chosen, content);
   tabStore.rebindPath(tabId, chosen, fileName);
   addRecentFile(chosen, fileName);
@@ -143,7 +144,7 @@ export async function reloadCurrentFile(path: string): Promise<void> {
     const content = await readMarkdownFile(absolutePath);
     const baseDir = getBaseDir(absolutePath);
     const result = renderFull(content, baseDir);
-    const fileName = absolutePath.split("/").pop() ?? absolutePath;
+    const fileName = basename(absolutePath);
 
     await allowAssets(result.assetPaths);
 

--- a/src/lib/utils/path.ts
+++ b/src/lib/utils/path.ts
@@ -1,0 +1,47 @@
+// Cross-platform path helpers.
+//
+// MDHero ships Windows, macOS and Linux builds, but several call sites derived
+// a file name with `path.split("/").pop()`. On Windows a path has no forward
+// slashes, so that returns the *entire* path — which is what the tab and window
+// titles were showing. These helpers handle both separators and are unit tested
+// against real paths from all three platforms.
+
+/**
+ * Last segment of a filesystem path — the file or folder name.
+ *
+ * Handles both separators, a trailing separator, and a path with no separator
+ * at all (returned unchanged). Only for real paths: the `paste://` / `url://` /
+ * `new://` tab sentinels contain `//` and would be cut at it, so callers filter
+ * those out before getting here (they carry their own display name anyway).
+ */
+export function basename(path: string): string {
+  const trimmed = path.replace(/[\\/]+$/, "");
+  const idx = Math.max(trimmed.lastIndexOf("/"), trimmed.lastIndexOf("\\"));
+  if (idx < 0) return trimmed || path;
+  return trimmed.slice(idx + 1) || trimmed;
+}
+
+/**
+ * Strip Windows' verbatim path prefix, which `Path::canonicalize` returns and
+ * which is correct but unreadable in a title bar: `\\?\C:\x` becomes `C:\x`,
+ * and the UNC form `\\?\UNC\server\share` folds back to `\\server\share`.
+ */
+export function stripVerbatimPrefix(path: string): string {
+  if (path.startsWith("\\\\?\\UNC\\")) return "\\\\" + path.slice(8);
+  if (path.startsWith("\\\\?\\")) return path.slice(4);
+  return path;
+}
+
+/**
+ * Collapse the user's home directory to `~` for display, on any platform:
+ * `/Users/<name>` (macOS), `/home/<name>` (Linux), `C:\Users\<name>` (Windows).
+ * Returns the path unchanged when it isn't under a home directory.
+ */
+export function shortenHomePath(path: string): string {
+  const normalized = stripVerbatimPrefix(path);
+  const match = normalized.match(
+    /^(?:\/Users\/|\/home\/|[A-Za-z]:[\\/]Users[\\/])[^\\/]+[\\/](.*)$/
+  );
+  if (!match) return normalized;
+  return "~/" + match[1].replace(/\\/g, "/");
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -15,6 +15,7 @@
     saveFile,
   } from "$lib/tauri/files";
   import { showToast } from "$lib/stores/toast";
+  import { basename } from "$lib/utils/path";
   import { settings, getContentMaxWidth } from "$lib/stores/settings";
   import { startFileWatcher } from "$lib/tauri/watcher";
   import { themeMode, cycleTheme } from "$lib/stores/theme";
@@ -283,7 +284,7 @@
         const saved = await saveAsNewDocument(tab.id, tab.editContent);
         if (!saved) return; // cancelled — keep editing, stays dirty
         targetPath = saved;
-        targetName = saved.split("/").pop() ?? saved;
+        targetName = basename(saved);
       } else {
         await saveFile(tab.filePath, tab.editContent);
       }
@@ -344,7 +345,7 @@
     if (!target) return;
 
     const resolved = resolveLocalPath(target, getBaseDir(tab.filePath));
-    const name = resolved.split(/[\\/]/).pop() || resolved;
+    const name = basename(resolved);
 
     if (!(await pathExists(resolved))) {
       showToast(`Can't find “${name}”`);

--- a/tests/unit/path.test.ts
+++ b/tests/unit/path.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { basename, shortenHomePath, stripVerbatimPrefix } from "../../src/lib/utils/path";
+
+// Windows paths are written with escaped backslashes throughout: "C:\\Users" is
+// the four-character path C:\Users.
+
+describe("basename", () => {
+  it("takes the last segment of a POSIX path", () => {
+    expect(basename("/Users/hugo/notes/readme.md")).toBe("readme.md");
+    expect(basename("/tmp/a.md")).toBe("a.md");
+  });
+
+  // The bug this module exists for: `split("/").pop()` returned the whole
+  // string here, so tab and window titles showed a full Windows path.
+  it("takes the last segment of a Windows path", () => {
+    expect(basename("C:\\Users\\hugo\\notes\\readme.md")).toBe("readme.md");
+    expect(basename("\\\\server\\share\\doc.md")).toBe("doc.md");
+  });
+
+  it("handles trailing separators and separator-free input", () => {
+    expect(basename("/Users/hugo/notes/")).toBe("notes");
+    expect(basename("C:\\Users\\hugo\\")).toBe("hugo");
+    expect(basename("readme.md")).toBe("readme.md");
+  });
+});
+
+describe("stripVerbatimPrefix", () => {
+  it("removes the verbatim prefix canonicalize() returns", () => {
+    expect(stripVerbatimPrefix("\\\\?\\C:\\Users\\hugo\\a.md")).toBe("C:\\Users\\hugo\\a.md");
+  });
+
+  it("restores a UNC path to its familiar form", () => {
+    expect(stripVerbatimPrefix("\\\\?\\UNC\\server\\share\\a.md")).toBe(
+      "\\\\server\\share\\a.md"
+    );
+  });
+
+  it("leaves ordinary paths alone", () => {
+    expect(stripVerbatimPrefix("/Users/hugo/a.md")).toBe("/Users/hugo/a.md");
+    expect(stripVerbatimPrefix("C:\\Users\\hugo\\a.md")).toBe("C:\\Users\\hugo\\a.md");
+  });
+});
+
+describe("shortenHomePath", () => {
+  it("collapses the home directory on every platform", () => {
+    expect(shortenHomePath("/Users/hugo/notes/a.md")).toBe("~/notes/a.md");
+    expect(shortenHomePath("/home/hugo/notes/a.md")).toBe("~/notes/a.md");
+    expect(shortenHomePath("C:\\Users\\hugo\\notes\\a.md")).toBe("~/notes/a.md");
+  });
+
+  it("strips a verbatim prefix before matching", () => {
+    expect(shortenHomePath("\\\\?\\C:\\Users\\hugo\\notes\\a.md")).toBe("~/notes/a.md");
+  });
+
+  it("leaves paths outside a home directory unchanged", () => {
+    expect(shortenHomePath("/tmp/a.md")).toBe("/tmp/a.md");
+    expect(shortenHomePath("D:\\repos\\a.md")).toBe("D:\\repos\\a.md");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #76, plus two other Windows-only defects with the same root cause: POSIX assumptions in shared code paths.

## Changes

- **`resolve_path` returns canonicalize()'s verbatim prefix** (`\?\C:\...`), which `normalizePath` then mangles — this is #76, where local images never render on Windows. Stripped on the Rust side, with the UNC form folded back to `\server\share`.
- **`list_claude_plans` reads `std::env::var("HOME")`**, which Windows does not set, so the command always errors and the "Plans" list is permanently empty on Windows builds. Added a `home_dir()` helper using `USERPROFILE` with the `HOMEDRIVE`/`HOMEPATH` fallback. No new crate — it's one lookup.
- **Tab and window titles came from `path.split("/").pop()`.** A Windows path contains no forward slash, so the "file name" was the entire path.
- Added `src/lib/utils/path.ts` (`basename`, `stripVerbatimPrefix`, `shortenHomePath`) to replace the copies of this logic in `files.ts`, `+page.svelte`, `EmptyState` and `OpenDialog` — including the two hardcoded `/Users/` prefixes that only shortened paths on macOS.

I hesitated on the new file given the "prefer editing over creating" guidance, but the logic had three existing copies and the Windows cases need real test coverage, so a small tested module seemed better than a fourth copy.

## Testing

- [ ] Tested in dev mode (`pnpm tauri dev`)
- [ ] Works in both light and dark mode
- [ ] No regressions in existing features
- [x] `pnpm check` passes

**Please read those boxes carefully rather than trusting them.** I have no MSVC Build Tools on this machine, so I could not run `pnpm tauri dev` and have **not** exercised this manually — including on Windows, which is the platform it targets. What I did verify:

- `pnpm test` passes (46 tests), including 9 new ones in `tests/unit/path.test.ts` covering POSIX, Windows, UNC and verbatim-prefix paths.
- `pnpm check` reports 7 errors / 9 warnings, which is **exactly the count on `main` today** — pre-existing (`Webview.print`, missing `node:*` types in `hljs-dark-coverage.test.ts`), none introduced here.
- The equivalent code compiled on all five platforms of the bundle matrix in my fork.

The Rust test for `strip_verbatim_prefix` is `#[cfg(windows)]`-gated, so it does not run on a Linux CI runner. Someone on Windows running `cargo test` would be the real confirmation.