### PR TITLE
Stop the file watcher when the last tab closes

### DIFF
--- a/src/lib/tauri/watcher.ts
+++ b/src/lib/tauri/watcher.ts
@@ -31,6 +31,13 @@ export async function startFileWatcher(filePath: string): Promise<void> {
   invoke("start_watching", { path: filePath }).catch(() => {});
 }
 
+/**
+ * Tear the watcher down on both sides of the IPC boundary.
+ *
+ * Dropping only the JS listener would leave the Rust debouncer watching the
+ * directory of a file nobody has open any more — it keeps a thread and an OS
+ * watch handle alive for the rest of the session.
+ */
 export function stopFileWatcher(): void {
   if (reloadTimeout) {
     clearTimeout(reloadTimeout);
@@ -40,4 +47,5 @@ export function stopFileWatcher(): void {
     unlisten();
     unlisten = null;
   }
+  invoke("stop_watching").catch(() => {});
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -16,7 +16,7 @@
   } from "$lib/tauri/files";
   import { showToast } from "$lib/stores/toast";
   import { settings, getContentMaxWidth } from "$lib/stores/settings";
-  import { startFileWatcher } from "$lib/tauri/watcher";
+  import { startFileWatcher, stopFileWatcher } from "$lib/tauri/watcher";
   import { themeMode, cycleTheme } from "$lib/stores/theme";
   import { getCurrentWindow } from "@tauri-apps/api/window";
   import { invoke } from "@tauri-apps/api/core";
@@ -1011,10 +1011,31 @@
     });
   });
 
-  // Watch for file path changes to set up watcher (only when path actually changes)
+  // Start/stop the file watcher as the active document changes.
+  //
+  // The stop half matters: closing the last tab leaves docStore.filePath null,
+  // and without an explicit teardown the watcher for the file just closed kept
+  // running. An external edit to it then fired reloadCurrentFile, which calls
+  // docStore.set — so a document the user had closed reappeared on top of the
+  // home screen. `url://` joins the sentinels here too: it is not a filesystem
+  // path, so start_watching could never do anything useful with it.
   $effect(() => {
     const path = $docStore.filePath;
-    if (path && !path.startsWith("paste://") && !path.startsWith("new://") && path !== lastWatchedPath) {
+    const watchable =
+      !!path
+      && !path.startsWith("paste://")
+      && !path.startsWith("new://")
+      && !path.startsWith("url://");
+
+    if (!watchable) {
+      if (lastWatchedPath !== null) {
+        lastWatchedPath = null;
+        stopFileWatcher();
+      }
+      return;
+    }
+
+    if (path !== lastWatchedPath) {
       lastWatchedPath = path;
       startFileWatcher(path);
     }

--- a/tests/unit/watcher.test.ts
+++ b/tests/unit/watcher.test.ts
@@ -15,10 +15,15 @@ const { startFileWatcher, stopFileWatcher } = await import("../../src/lib/tauri/
 
 describe("file watcher", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    // Order matters twice over. The mocks are configured first because
+    // stopFileWatcher now invokes "stop_watching" and awaits it — an
+    // unconfigured vi.fn() returns undefined, not a promise. Then the teardown
+    // runs, and clearAllMocks wipes its calls so they don't land in the
+    // per-test counts below (it clears calls only, implementations survive).
     listen.mockResolvedValue(vi.fn());
     invoke.mockResolvedValue(undefined);
     stopFileWatcher();
+    vi.clearAllMocks();
   });
 
   it("restarts the backend watcher when switching between file tabs", async () => {
@@ -31,6 +36,20 @@ describe("file watcher", () => {
     expect(invoke).toHaveBeenNthCalledWith(3, "start_watching", { path: "C:/docs/a.md" });
     expect(invoke).toHaveBeenCalledTimes(3);
     expect(listen).toHaveBeenCalledTimes(3);
+  });
+
+  // Closing the last tab used to leave the Rust watcher running: an external
+  // edit to the closed file then pushed it back into the document store, on top
+  // of the home screen.
+  it("stops the backend watcher, not just the event listener", async () => {
+    const firstUnlisten = vi.fn();
+    listen.mockResolvedValueOnce(firstUnlisten);
+
+    await startFileWatcher("C:/docs/a.md");
+    stopFileWatcher();
+
+    expect(firstUnlisten).toHaveBeenCalledOnce();
+    expect(invoke).toHaveBeenLastCalledWith("stop_watching");
   });
 
   it("unsubscribes the previous event listener when switching files", async () => {


### PR DESCRIPTION
## Summary

Closing the last tab leaves a file watcher running. An external edit to that closed file then puts the document back on screen, over the home view.

## Changes

- The watcher is started when a document becomes active but never stopped. Closing the last tab leaves `docStore.filePath` null, so the start effect simply doesn't re-run and the watcher for the file just closed stays live. An external edit then fires `reloadCurrentFile`, whose `docStore.set` re-displays the closed document. The effect now tears the watcher down when no watchable document is active.
- `stopFileWatcher` also invokes the `stop_watching` command. It previously dropped only the JS listener, leaving the Rust debouncer holding a thread and an OS watch handle for the rest of the session — `stop_watching` had no caller at all.
- `url://` tabs join the `paste://` / `new://` sentinels in the exclusion list; they aren't filesystem paths, so `start_watching` can do nothing with one.

## Testing

- [ ] Tested in dev mode (`pnpm tauri dev`)
- [ ] Works in both light and dark mode
- [ ] No regressions in existing features
- [x] `pnpm check` passes

No MSVC Build Tools on this machine, so `pnpm tauri dev` was not possible and this is **not** manually verified. To reproduce the original bug: open a file, close the tab, then edit that file in another editor — the closed document reappears.

`pnpm test` passes, with a test added to `tests/unit/watcher.test.ts` asserting the backend watcher is stopped and not just the event listener. `pnpm check` shows the same 7 errors / 9 warnings as `main` today; none are introduced here.

One note on the existing test file: the new teardown call had to move ahead of `vi.clearAllMocks()` in `beforeEach`, and the mocks have to be configured before it, or `stopFileWatcher` gets `undefined` back from an unconfigured `vi.fn()` instead of a promise. The comment there explains the ordering.