### PR TITLE
Wire File > Close Tab, which is currently a dead menu item

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -126,6 +126,9 @@ pub fn run() {
                         "find" => {
                             let _ = window.eval("window.__mdhero_find?.()");
                         }
+                        "close" => {
+                            let _ = window.eval("window.__mdhero_close_tab?.()");
+                        }
                         "check_updates" => {
                             let _ = window.eval("window.__mdhero_check_updates?.()");
                         }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -450,6 +450,23 @@
     return true;
   }
 
+  // Close the active tab, from either Cmd+W route (the File > Close Tab menu
+  // item, or the keydown fallback). The guard makes a double-fire harmless: if
+  // a platform delivers both the menu accelerator and the keydown for one press,
+  // the second call returns instead of closing a second tab. handleCloseTab
+  // always awaits at least a microtask, so the flag is set before it can re-enter.
+  let closeInFlight = false;
+  async function closeActiveTab() {
+    if (closeInFlight) return;
+    closeInFlight = true;
+    try {
+      const t = tabStore.getActiveTab();
+      if (t) await handleCloseTab(t.id);
+    } finally {
+      closeInFlight = false;
+    }
+  }
+
   // Close-on-ESC: close the active file tab, and quit the app if it was the last
   // one (on macOS closing the window alone leaves the app in the dock). Async
   // because the dirty-confirm dialog is — a cancelled discard must not quit.
@@ -487,6 +504,13 @@
     };
     (window as any).__mdhero_find = () => {
       searchVisible = !searchVisible;
+    };
+    // File > Close Tab (Cmd/Ctrl+W). The menu item declared this accelerator
+    // but lib.rs had no branch for its id, so the event was dropped — and
+    // because the native menu consumes the key, the keydown fallback never ran
+    // either: the shortcut and the menu item were both dead.
+    (window as any).__mdhero_close_tab = () => {
+      void closeActiveTab();
     };
     (window as any).__mdhero_zen = () => {
       zenMode = !zenMode;
@@ -824,12 +848,12 @@
       return;
     }
 
-    // Cmd+W close tab (with dirty confirm)
+    // Cmd+W close tab (with dirty confirm). Usually dead code: the File menu
+    // binds the same accelerator and native menus consume the key before the
+    // webview sees it. Kept as the fallback for any platform where it doesn't.
     if ((e.metaKey || e.ctrlKey) && e.key === "w") {
       e.preventDefault();
-      const t = tabStore.getActiveTab();
-      if (!t) return;
-      void handleCloseTab(t.id);
+      void closeActiveTab();
       return;
     }
     if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === "f") {


### PR DESCRIPTION
## Summary

`File > Close Tab` and its Cmd/Ctrl+W accelerator do nothing today.

## Changes

- `menu.rs` declares a `close` item with the `CmdOrCtrl+W` accelerator, but `lib.rs`'s `on_menu_event` has no branch for that id, so the event is dropped. The keydown fallback in `+page.svelte` never compensates, because a native menu accelerator consumes the key before the webview sees it — so the menu item and the shortcut are both inert.
- Routes the menu event to a `__mdhero_close_tab` hook, alongside the existing `__mdhero_open_file` / `__mdhero_find` / `__mdhero_quit` hooks.
- Funnels the menu event and the keydown through one `closeActiveTab` guarded against re-entry, so if any platform does deliver both for a single press, it closes one tab rather than two.

The dirty-tab confirmation is untouched — both routes go through the existing `handleCloseTab`.

## Testing

- [ ] Tested in dev mode (`pnpm tauri dev`)
- [ ] Works in both light and dark mode
- [ ] No regressions in existing features
- [x] `pnpm check` passes

No MSVC Build Tools on this machine, so this is **not** manually verified — and for a menu fix, manual verification is really the only meaningful test. What I can say: it compiled on all five platforms of the bundle matrix in my fork, `pnpm test` passes, and `pnpm check` shows the same 7 errors / 9 warnings as `main`.

Worth checking on macOS specifically, since that is where the accelerator-consumes-the-key behaviour is most certain and where the re-entry guard would matter least.