### PR TITLE
fix: Linux Window menu, platform-correct shortcut labels, canonical repo URLs

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Discussions
-    url: https://github.com/vaibhavuk-dev/mdhero/discussions
+    url: https://github.com/vaibhav-kakde-in/mdhero/discussions
     about: Ask questions or share ideas in Discussions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ Small PRs (bug fixes, typos, minor tweaks) don't need an issue first.
 
 ```bash
 # Clone
-git clone https://github.com/vaibhavuk-dev/mdhero.git
+git clone https://github.com/vaibhav-kakde-in/mdhero.git
 cd mdhero
 
 # Install dependencies

--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@
 A beautiful, native Markdown viewer and lightweight editor for macOS and Windows. ~8MB. Free. Open source.
 <br><br>
 
-[![GitHub Stars](https://img.shields.io/github/stars/vaibhavuk-dev/mdhero?style=flat-square)](https://github.com/vaibhavuk-dev/mdhero/stargazers)
-[![Downloads](https://img.shields.io/github/downloads/vaibhavuk-dev/mdhero/total?style=flat-square)](https://github.com/vaibhavuk-dev/mdhero/releases/latest)
-[![License](https://img.shields.io/github/license/vaibhavuk-dev/mdhero?style=flat-square)](LICENSE)
+[![GitHub Stars](https://img.shields.io/github/stars/vaibhav-kakde-in/mdhero?style=flat-square)](https://github.com/vaibhav-kakde-in/mdhero/stargazers)
+[![Downloads](https://img.shields.io/github/downloads/vaibhav-kakde-in/mdhero/total?style=flat-square)](https://github.com/vaibhav-kakde-in/mdhero/releases/latest)
+[![License](https://img.shields.io/github/license/vaibhav-kakde-in/mdhero?style=flat-square)](LICENSE)
 ![macOS](https://img.shields.io/badge/macOS-supported-blue?style=flat-square&logo=apple)
 ![Windows](https://img.shields.io/badge/Windows-supported-blue?style=flat-square&logo=windows)
 [![Built with Tauri](https://img.shields.io/badge/Built_with-Tauri-FFC131?style=flat-square&logo=tauri)](https://tauri.app)
 
-[Download](https://github.com/vaibhavuk-dev/mdhero/releases/latest) · [Website](https://mdhero.app) · [Discussions](https://github.com/vaibhavuk-dev/mdhero/discussions)
+[Download](https://github.com/vaibhav-kakde-in/mdhero/releases/latest) · [Website](https://mdhero.app) · [Discussions](https://github.com/vaibhav-kakde-in/mdhero/discussions)
 
 </div>
 
@@ -115,9 +115,9 @@ Distraction-free full-screen reading. Just you and the document.
 
 ## Install
 
-**macOS**: Download `.dmg` from [Releases →](https://github.com/vaibhavuk-dev/mdhero/releases/latest)
+**macOS**: Download `.dmg` from [Releases →](https://github.com/vaibhav-kakde-in/mdhero/releases/latest)
 
-**Windows**: Download `.msi` from [Releases →](https://github.com/vaibhavuk-dev/mdhero/releases/latest)
+**Windows**: Download `.msi` from [Releases →](https://github.com/vaibhav-kakde-in/mdhero/releases/latest)
 
 Or build from source (see below).
 

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -1,5 +1,5 @@
 use tauri::{
-    menu::{Menu, MenuItem, PredefinedMenuItem, Submenu, WINDOW_SUBMENU_ID},
+    menu::{IsMenuItem, Menu, MenuItem, PredefinedMenuItem, Submenu},
     AppHandle, Runtime,
 };
 
@@ -89,9 +89,15 @@ pub fn create_menu<R: Runtime>(app: &AppHandle<R>) -> Result<Menu<R>, tauri::Err
     //
     // `close_window` is intentionally omitted: its default accelerator is
     // Cmd+W, which the app already binds in the File menu to "Close Tab".
+    //
+    // Not built on Linux. Its two entries, `minimize` and `maximize`, are
+    // documented by muda as "Linux: Unsupported" — GTK creates nothing for
+    // them, so the menu opened as an empty panel (#62, Ubuntu screenshot).
+    // Windows implements both, so it keeps the submenu.
+    #[cfg(not(target_os = "linux"))]
     let window_menu = Submenu::with_id_and_items(
         app,
-        WINDOW_SUBMENU_ID,
+        tauri::menu::WINDOW_SUBMENU_ID,
         "Window",
         true,
         &[
@@ -100,10 +106,12 @@ pub fn create_menu<R: Runtime>(app: &AppHandle<R>) -> Result<Menu<R>, tauri::Err
         ],
     )?;
 
-    let menu = Menu::with_items(
-        app,
-        &[&app_menu, &file_menu, &edit_menu, &view_menu, &window_menu],
-    )?;
+    #[cfg(not(target_os = "linux"))]
+    let items: [&dyn IsMenuItem<R>; 5] = [&app_menu, &file_menu, &edit_menu, &view_menu, &window_menu];
+    #[cfg(target_os = "linux")]
+    let items: [&dyn IsMenuItem<R>; 4] = [&app_menu, &file_menu, &edit_menu, &view_menu];
+
+    let menu = Menu::with_items(app, &items)?;
 
     Ok(menu)
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -65,7 +65,7 @@
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDQ4MkY2OUE5MDM5N0ZCQTgKUldTbys1Y0RxV2t2U0d5TUQ5SU42amVWVWlTUGhTRXBydTZnQXNHL0VHNFM4Z2VMazh3Nm9qcDgK",
       "endpoints": [
-        "https://github.com/vaibhavuk-dev/mdhero/releases/latest/download/latest.json"
+        "https://github.com/vaibhav-kakde-in/mdhero/releases/latest/download/latest.json"
       ],
       "windows": {
         "installMode": "passive"

--- a/src/lib/components/AboutDialog.svelte
+++ b/src/lib/components/AboutDialog.svelte
@@ -46,11 +46,11 @@
           <p class="app-description">A beautiful, fast Markdown viewer for your desktop.</p>
           <a
             class="app-link"
-            href="https://github.com/vaibhavuk-dev/mdhero"
+            href="https://github.com/vaibhav-kakde-in/mdhero"
             target="_blank"
             rel="noopener noreferrer"
           >
-            github.com/vaibhavuk-dev/mdhero
+            github.com/vaibhav-kakde-in/mdhero
           </a>
         </div>
       </div>

--- a/src/lib/components/EmptyState.svelte
+++ b/src/lib/components/EmptyState.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { invoke } from "@tauri-apps/api/core";
+  import { MOD } from "$lib/utils/platform";
   import { open } from "@tauri-apps/plugin-dialog";
   import { openFileDialog, openFile, newDocument } from "../tauri/files";
   import { recentFiles, clearRecentFiles } from "../stores/recents";
@@ -226,7 +227,7 @@
   <!-- Footer -->
   <div class="footer-row">
     <div class="footer-hint">
-      <kbd>Cmd+O</kbd> browse &middot; <kbd>Cmd+Shift+V</kbd> paste &middot; <kbd>Cmd+T</kbd> new tab
+      <kbd>{MOD}+O</kbd> browse &middot; <kbd>{MOD}+Shift+V</kbd> paste &middot; <kbd>{MOD}+T</kbd> new tab
       {#if plansHidden && plans.length > 0}
         &middot; <button class="footer-link" onclick={showPlans}>Show Claude Plans</button>
       {/if}

--- a/src/lib/components/OpenDialog.svelte
+++ b/src/lib/components/OpenDialog.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { invoke } from "@tauri-apps/api/core";
+  import { MOD } from "$lib/utils/platform";
   import { open as openDirDialog } from "@tauri-apps/plugin-dialog";
   import { openFile, openFileDialog } from "$lib/tauri/files";
   import { recentFiles, removeRecentFile } from "$lib/stores/recents";
@@ -200,7 +201,7 @@
             <path d="M2 5l4-3h8v11H2V5z"/><line x1="2" y1="5" x2="6" y2="5"/>
           </svg>
           <span>Browse Files...</span>
-          <span class="browse-hint">Cmd+O</span>
+          <span class="browse-hint">{MOD}+O</span>
         </button>
         <div class="url-row">
           <input

--- a/src/lib/components/PasteModal.svelte
+++ b/src/lib/components/PasteModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { isLlmEscaped, unescapeLlmOutput } from "$lib/utils/llm";
+  import { MOD } from "$lib/utils/platform";
   import { isUrl, toRawUrl, urlToFileName } from "$lib/utils/url";
   import { renderFull } from "$lib/renderer/pipeline";
   import { tabStore } from "$lib/stores/tabs";
@@ -185,7 +186,7 @@
         </div>
 
         <div class="modal-footer">
-          <span class="modal-hint">Cmd+Enter to render</span>
+          <span class="modal-hint">{MOD}+Enter to render</span>
           <div class="modal-actions">
             <button onclick={() => (visible = false)} class="btn-cancel">Cancel</button>
             <button onclick={handleRender} disabled={!text.trim()} class="btn-render">Render</button>
@@ -220,7 +221,7 @@
         </div>
 
         <div class="modal-footer">
-          <span class="modal-hint">Cmd+Enter to fetch</span>
+          <span class="modal-hint">{MOD}+Enter to fetch</span>
           <div class="modal-actions">
             <button onclick={() => (visible = false)} class="btn-cancel">Cancel</button>
           </div>

--- a/src/lib/components/Toolbar.svelte
+++ b/src/lib/components/Toolbar.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { document } from "../stores/document";
+  import { MOD } from "$lib/utils/platform";
   import { settings } from "../stores/settings";
   import { themeMode, cycleTheme } from "../stores/theme";
   import { tocVisible, tocEntries, toggleToc, activeHeadingId } from "../stores/toc";
@@ -122,10 +123,10 @@
     <img src={brandLogo} alt="MDHero" width="26" height="26" class="toolbar-logo" />
     <span class="toolbar-wordmark">MDHero</span>
     <div class="btn-group">
-      <button onclick={onOpen} class="btn btn-primary" title="Open file (Cmd+O)">
+      <button onclick={onOpen} class="btn btn-primary" title="Open file ({MOD}+O)">
         Open
       </button>
-      <button onclick={onPaste} class="btn btn-ghost" title="Paste markdown (Cmd+Shift+V)">
+      <button onclick={onPaste} class="btn btn-ghost" title="Paste markdown ({MOD}+Shift+V)">
         Paste
       </button>
       <button onclick={onUrl} class="btn btn-ghost" title="Open URL">
@@ -234,7 +235,7 @@
         ? 'View raw markdown (open a file first)'
         : isEditing
         ? 'View raw markdown (exit edit mode to use)'
-        : 'View raw markdown (Cmd+U)'}
+        : `View raw markdown (${MOD}+U)`}
     >
       <svg width="20" height="20" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
         <polyline points="6,5 2,8 6,11"/>
@@ -264,7 +265,7 @@
       class="btn btn-icon save-btn"
       class:dirty
       disabled={!dirty}
-      title={dirty ? 'Save unsaved changes (Cmd+S)' : 'Save (no changes to save)'}
+      title={dirty ? `Save unsaved changes (${MOD}+S)` : 'Save (no changes to save)'}
     >
       <svg width="20" height="20" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
         <path d="M3 3h8l2 2v8H3z"/>
@@ -331,7 +332,7 @@
     <button
       onclick={() => { closeAll(); onOpenSettings(); }}
       class="btn btn-icon"
-      title="Settings (Cmd+,)"
+      title="Settings ({MOD}+,)"
       aria-label="Settings"
     >
       <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">

--- a/src/lib/stores/updater.ts
+++ b/src/lib/stores/updater.ts
@@ -10,7 +10,7 @@ function detectOS(): string {
 }
 
 const PRIMARY_ENDPOINT = "https://mdhero.app/api/version";
-const FALLBACK_GITHUB = "https://api.github.com/repos/vaibhavuk-dev/mdhero/releases/latest";
+const FALLBACK_GITHUB = "https://api.github.com/repos/vaibhav-kakde-in/mdhero/releases/latest";
 
 const CHECK_INTERVAL = 24 * 60 * 60 * 1000; // 24 hours
 const LAST_CHECK_KEY = "mdhero_update_check";

--- a/src/lib/utils/platform.ts
+++ b/src/lib/utils/platform.ts
@@ -1,0 +1,22 @@
+// Platform helpers for user-facing strings.
+//
+// The keyboard handlers already accept both metaKey and ctrlKey, so shortcuts
+// *work* everywhere — but every label said "Cmd", which is wrong on the first
+// screen a Windows or Linux user sees. Derive the label once, from the
+// platform, and use it wherever a shortcut is shown.
+
+/**
+ * "Cmd" on macOS, "Ctrl" everywhere else.
+ *
+ * Takes the platform string as a parameter so it is unit-testable without a
+ * DOM; the default reads `navigator.platform`, guarded for environments where
+ * `navigator` does not exist (the same guard `stores/updater.ts` uses).
+ */
+export function modifierKeyLabel(
+  platform: string = typeof navigator !== "undefined" ? navigator.platform : ""
+): string {
+  return /^mac/i.test(platform) ? "Cmd" : "Ctrl";
+}
+
+/** The label for this session's platform, resolved once at module load. */
+export const MOD = modifierKeyLabel();

--- a/tests/unit/platform.test.ts
+++ b/tests/unit/platform.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { modifierKeyLabel } from "../../src/lib/utils/platform";
+
+// Every shortcut label used to be hardcoded "Cmd" (#62's Ubuntu screenshot
+// shows `Cmd+O` on the Linux home screen). The label is now derived from the
+// platform string, which is what these pin down.
+describe("modifierKeyLabel", () => {
+  it("is Cmd on macOS", () => {
+    expect(modifierKeyLabel("MacIntel")).toBe("Cmd");
+    expect(modifierKeyLabel("macOS")).toBe("Cmd");
+  });
+
+  it("is Ctrl on Windows and Linux", () => {
+    expect(modifierKeyLabel("Win32")).toBe("Ctrl");
+    expect(modifierKeyLabel("Linux x86_64")).toBe("Ctrl");
+    expect(modifierKeyLabel("Linux aarch64")).toBe("Ctrl");
+  });
+
+  it("falls back to Ctrl when the platform is unknown", () => {
+    // An unknown platform must not claim a Command key it may not have.
+    expect(modifierKeyLabel("")).toBe("Ctrl");
+  });
+});


### PR DESCRIPTION
Three findings from reviewing #62, all visible in the Ubuntu screenshot @arfshl posted there, all small, all worth landing before the first Linux release.

## Window menu is empty on Linux

`menu.rs` built the Window submenu from `PredefinedMenuItem::minimize` and `::maximize`, which muda documents as **"Linux: Unsupported"** — GTK creates nothing for them, so the menu opened as a blank panel. The submenu is now built under `#[cfg(not(target_os = "linux"))]`; Windows implements both items and keeps it. The `menu_window` integration test still passes on macOS/Windows (it skips Linux by design). **The Linux CI job on this PR is the real proof** — the gated path can only be compiled there.

## Shortcut labels said "Cmd" on every platform

The key handlers already accept `Ctrl`, so shortcuts worked; only the labels were wrong — the home-screen hints, five toolbar tooltips, the open dialog and the paste modal. One platform-derived `modifierKeyLabel()` in `src/lib/utils/platform.ts` replaces all ten strings, with unit tests for `MacIntel → Cmd`, `Win32`/`Linux → Ctrl`, unknown → `Ctrl`.

## Repo URLs pointed at the pre-rename name

The updater endpoint, its API fallback in `updater.ts`, the About dialog, README, CONTRIBUTING and the issue-template config all used `vaibhavuk-dev/mdhero`. That works today only through GitHub's 301 rename redirect, which lasts exactly as long as nobody registers the old username. Updates are minisign-signed so a squatter couldn't serve a malicious build, but they could stop every installed copy from finding updates. All nine occurrences now use `vaibhav-kakde-in/mdhero`.

## Verification

- `pnpm test`: 50/50 (47 + 3 new); `pnpm check`: 4 errors / 9 warnings, identical to `main`
- `cargo build` and `cargo test --test menu_window` pass on macOS
- Not verifiable locally: the Linux `cfg` path — see the `ubuntu-22.04` job here

Refs #62.
