### PR TITLE
docs: list Linux and Windows ARM in the install sections

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -217,8 +217,9 @@ jobs:
             See the full changelog in the [commit history](https://github.com/${{ github.repository }}/commits/${{ github.ref_name }}).
 
             ## Install
-            - **macOS**: Download the `.dmg` file
-            - **Windows**: Download the `.msi` installer or `.exe` (NSIS)
+            - **macOS** (Apple Silicon): Download the `.dmg` file
+            - **Windows** (x64 or ARM64): Download the `.msi` installer or `-setup.exe` (NSIS) — pick the `x64` or `arm64` file for your machine
+            - **Linux** (x64 or arm64): Download the `.deb` (Debian/Ubuntu), `.rpm` (Fedora/openSUSE) or `.AppImage` (any distro) — `amd64`/`x86_64` or `arm64`/`aarch64`
           releaseDraft: false
           prerelease: false
 

--- a/README.md
+++ b/README.md
@@ -115,9 +115,11 @@ Distraction-free full-screen reading. Just you and the document.
 
 ## Install
 
-**macOS**: Download `.dmg` from [Releases →](https://github.com/vaibhav-kakde-in/mdhero/releases/latest)
+**macOS** (Apple Silicon): Download `.dmg` from [Releases →](https://github.com/vaibhav-kakde-in/mdhero/releases/latest)
 
-**Windows**: Download `.msi` from [Releases →](https://github.com/vaibhav-kakde-in/mdhero/releases/latest)
+**Windows** (x64 or ARM64): Download `.msi` or `-setup.exe` from [Releases →](https://github.com/vaibhav-kakde-in/mdhero/releases/latest) — pick the `x64` or `arm64` file for your machine
+
+**Linux** (x64 or arm64): Download `.deb` (Debian/Ubuntu), `.rpm` (Fedora/openSUSE) or `.AppImage` (any distro) from [Releases →](https://github.com/vaibhav-kakde-in/mdhero/releases/latest) — `amd64`/`x86_64` or `arm64`/`aarch64`
 
 Or build from source (see below).
 


### PR DESCRIPTION
The release-notes template in `build.yml` and the README install section both still said macOS and Windows only. Since #75, #80 and #79 the release carries five platforms — Linux x64 and arm64 (`.deb`, `.rpm`, `.AppImage`) and Windows 11 ARM alongside Windows x64. Both now list all of them, with a hint on which file to pick per architecture.

Kept separate from the version-bump commit on purpose. The release body is generated from the tagged commit, so this needs to be on `main` before the tag.

Docs + release template only; no code. Refs #62.
