### PR TITLE
fix: bound the asset-protocol scope to the document's own tree

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -166,7 +166,19 @@ pub fn partition_assets(
     pinned_folders: &[String],
     paths: &[String],
 ) -> (Vec<PathBuf>, Vec<String>) {
-    let roots = asset_roots(document_path, pinned_folders);
+    let ceiling = home_dir().and_then(|h| fs::canonicalize(h).ok());
+    partition_assets_below(document_path, pinned_folders, paths, ceiling.as_deref())
+}
+
+/// [`partition_assets`] with an explicit ceiling for the git-root walk; see
+/// [`git_root`]. Split out so the ceiling is testable without a real home.
+fn partition_assets_below(
+    document_path: &Path,
+    pinned_folders: &[String],
+    paths: &[String],
+    ceiling: Option<&Path>,
+) -> (Vec<PathBuf>, Vec<String>) {
+    let roots = asset_roots(document_path, pinned_folders, ceiling);
     let mut allowed = Vec::new();
     let mut rejected = Vec::new();
     for p in paths {
@@ -190,11 +202,11 @@ pub fn partition_assets(
 /// Everything is canonicalized so comparison happens on real paths. A document
 /// that does not exist on disk (`new://`, `paste://`) contributes no root, so
 /// only pinned folders remain.
-fn asset_roots(document_path: &Path, pinned_folders: &[String]) -> Vec<PathBuf> {
+fn asset_roots(document_path: &Path, pinned_folders: &[String], ceiling: Option<&Path>) -> Vec<PathBuf> {
     let mut roots = Vec::new();
     if let Ok(doc) = fs::canonicalize(document_path) {
         if let Some(dir) = doc.parent() {
-            roots.push(git_root(dir).unwrap_or_else(|| dir.to_path_buf()));
+            roots.push(git_root(dir, ceiling).unwrap_or_else(|| dir.to_path_buf()));
         }
     }
     for folder in pinned_folders {
@@ -209,8 +221,14 @@ fn asset_roots(document_path: &Path, pinned_folders: &[String]) -> Vec<PathBuf> 
 
 /// Nearest ancestor (including `dir` itself) that holds a `.git` entry — a
 /// directory for a normal checkout, a file for worktrees and submodules.
-fn git_root(dir: &Path) -> Option<PathBuf> {
+///
+/// The walk never reaches `ceiling` (the home directory in production), any
+/// ancestor of it, or a filesystem root. Without that, a dotfiles repo at
+/// `~/.git` would widen every document under home to the whole home
+/// directory — exactly the exposure this bound exists to remove.
+fn git_root(dir: &Path, ceiling: Option<&Path>) -> Option<PathBuf> {
     dir.ancestors()
+        .take_while(|a| a.parent().is_some() && ceiling.map_or(true, |c| !c.starts_with(a)))
         .find(|a| a.join(".git").exists())
         .map(Path::to_path_buf)
 }
@@ -519,7 +537,7 @@ mod tests {
 
 #[cfg(test)]
 mod asset_scope_tests {
-    use super::partition_assets;
+    use super::{partition_assets, partition_assets_below};
     use std::fs;
     use std::path::{Path, PathBuf};
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -604,6 +622,43 @@ mod asset_scope_tests {
 
         assert_eq!(allowed, vec![fs::canonicalize(&inside).unwrap()]);
         assert_eq!(rejected, vec![above]);
+    }
+
+    #[test]
+    fn never_widens_to_the_ceiling_or_above_it() {
+        // A dotfiles checkout at ~/.git must not turn "~" into an asset root.
+        let dir = scratch();
+        let home = dir.join("home");
+        fs::create_dir_all(home.join(".git")).unwrap();
+        fs::create_dir_all(dir.join(".git")).unwrap(); // and one above home
+        let doc = home.join("notes").join("note.md");
+        touch(&doc);
+        let elsewhere = touch(&home.join("Pictures").join("pic.png"));
+        let beside = touch(&home.join("notes").join("pic.png"));
+        let ceiling = fs::canonicalize(&home).unwrap();
+
+        let (allowed, rejected) =
+            partition_assets_below(&doc, &[], &[elsewhere.clone(), beside.clone()], Some(&ceiling));
+
+        assert_eq!(allowed, vec![fs::canonicalize(&beside).unwrap()]);
+        assert_eq!(rejected, vec![elsewhere]);
+    }
+
+    #[test]
+    fn a_checkout_below_the_ceiling_still_widens() {
+        let dir = scratch();
+        let home = dir.join("home");
+        let repo = home.join("code").join("repo");
+        fs::create_dir_all(repo.join(".git")).unwrap();
+        let doc = repo.join("docs").join("guide.md");
+        touch(&doc);
+        let inside = touch(&repo.join("assets").join("d.png"));
+        let ceiling = fs::canonicalize(&home).unwrap();
+
+        let (allowed, rejected) = partition_assets_below(&doc, &[], &[inside], Some(&ceiling));
+
+        assert_eq!(allowed.len(), 1);
+        assert!(rejected.is_empty());
     }
 
     #[test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
 use tauri::{
@@ -125,23 +125,94 @@ pub fn path_exists(path: String) -> bool {
     Path::new(&path).exists()
 }
 
-/// Allow the webview's asset protocol to serve specific image files.
+/// Allow the webview's asset protocol to serve specific image files — but only
+/// files a document is entitled to.
 ///
-/// The static `assetProtocol.scope` in tauri.conf.json only covers `$HOME`, so
-/// documents opened from elsewhere (external drives, /tmp, repos outside home)
-/// can't load their local images (issue #31). The frontend resolves each
-/// referenced image to an absolute path during rendering and passes them here
-/// so we whitelist exactly those files at runtime — tighter than widening the
-/// static scope. Re-allowing an already-allowed path is a no-op.
+/// The frontend resolves every local `<img src>` to an absolute path during
+/// rendering and hands the list here (issue #31). Each path is canonicalized
+/// (so symlinks cannot smuggle a file in) and must sit inside one of the
+/// document's asset roots, see [`asset_roots`]. Anything else is refused and
+/// returned to the caller so it can be logged. There is no static scope in
+/// `tauri.conf.json` any more: the only files the webview can ever fetch are
+/// the ones a document legitimately referenced from its own tree.
+///
+/// Why the bound matters: DOMPurify is the only thing between a markdown file
+/// and script execution in the webview, and `csp` is null. Before this check a
+/// document could write `![x](../../../.ssh/id_rsa)` and make that file
+/// fetchable, so a single sanitizer bypass would have been a file-exfiltration
+/// primitive across the whole disk. Now it is bounded to what the user opened.
 #[tauri::command]
-pub fn allow_assets(app: AppHandle, paths: Vec<String>) -> Result<(), String> {
+pub fn allow_assets(
+    app: AppHandle,
+    document_path: String,
+    pinned_folders: Vec<String>,
+    paths: Vec<String>,
+) -> Result<Vec<String>, String> {
+    let (allowed, rejected) = partition_assets(Path::new(&document_path), &pinned_folders, &paths);
     let scope = app.asset_protocol_scope();
-    for p in &paths {
+    for p in &allowed {
         scope
             .allow_file(p)
-            .map_err(|e| format!("Failed to allow asset {}: {}", p, e))?;
+            .map_err(|e| format!("Failed to allow asset {}: {}", p.display(), e))?;
     }
-    Ok(())
+    Ok(rejected)
+}
+
+/// Split the requested asset paths into the canonical files that may be
+/// served and the requests that must be refused. Pure so it can be tested
+/// without an app handle.
+pub fn partition_assets(
+    document_path: &Path,
+    pinned_folders: &[String],
+    paths: &[String],
+) -> (Vec<PathBuf>, Vec<String>) {
+    let roots = asset_roots(document_path, pinned_folders);
+    let mut allowed = Vec::new();
+    let mut rejected = Vec::new();
+    for p in paths {
+        match fs::canonicalize(p) {
+            Ok(c) if c.is_file() && roots.iter().any(|r| c.starts_with(r)) => allowed.push(c),
+            _ => rejected.push(p.clone()),
+        }
+    }
+    (allowed, rejected)
+}
+
+/// The directory trees a document may load images from:
+///
+/// 1. the directory the document lives in — widened to the enclosing git
+///    checkout when there is one, because `docs/guide.md` referencing
+///    `../assets/diagram.png` is how repositories are laid out;
+/// 2. every folder the user pinned in the sidebar — an explicit act of trust
+///    and the escape hatch for vaults that keep attachments beside the notes
+///    tree rather than inside it.
+///
+/// Everything is canonicalized so comparison happens on real paths. A document
+/// that does not exist on disk (`new://`, `paste://`) contributes no root, so
+/// only pinned folders remain.
+fn asset_roots(document_path: &Path, pinned_folders: &[String]) -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    if let Ok(doc) = fs::canonicalize(document_path) {
+        if let Some(dir) = doc.parent() {
+            roots.push(git_root(dir).unwrap_or_else(|| dir.to_path_buf()));
+        }
+    }
+    for folder in pinned_folders {
+        if let Ok(f) = fs::canonicalize(folder) {
+            if f.is_dir() {
+                roots.push(f);
+            }
+        }
+    }
+    roots
+}
+
+/// Nearest ancestor (including `dir` itself) that holds a `.git` entry — a
+/// directory for a normal checkout, a file for worktrees and submodules.
+fn git_root(dir: &Path) -> Option<PathBuf> {
+    dir.ancestors()
+        .find(|a| a.join(".git").exists())
+        .map(Path::to_path_buf)
 }
 
 #[tauri::command]
@@ -443,5 +514,188 @@ mod tests {
             strip_verbatim_prefix(r"C:\Users\hugo\a.md".to_string()),
             r"C:\Users\hugo\a.md"
         );
+    }
+}
+
+#[cfg(test)]
+mod asset_scope_tests {
+    use super::partition_assets;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+    /// A fresh directory under the OS temp dir. On macOS that lives behind a
+    /// symlink (`/var` → `/private/var`), which is deliberate: it proves the
+    /// comparison happens on canonical paths, not on the strings handed in.
+    fn scratch() -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "mdhero-asset-scope-{}-{}",
+            std::process::id(),
+            COUNTER.fetch_add(1, Ordering::SeqCst)
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn touch(path: &Path) -> String {
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, b"x").unwrap();
+        path.to_string_lossy().into_owned()
+    }
+
+    fn s(p: &Path) -> String {
+        p.to_string_lossy().into_owned()
+    }
+
+    #[test]
+    fn accepts_an_image_beside_the_document_and_returns_it_canonical() {
+        let dir = scratch();
+        let doc = dir.join("note.md");
+        touch(&doc);
+        let pic = touch(&dir.join("pic.png"));
+
+        let (allowed, rejected) = partition_assets(&doc, &[], &[pic.clone()]);
+
+        assert_eq!(allowed, vec![fs::canonicalize(&pic).unwrap()]);
+        assert!(rejected.is_empty());
+    }
+
+    #[test]
+    fn accepts_images_in_subfolders_of_the_document() {
+        let dir = scratch();
+        let doc = dir.join("note.md");
+        touch(&doc);
+        let pic = touch(&dir.join("img").join("deep").join("pic.png"));
+
+        let (allowed, rejected) = partition_assets(&doc, &[], &[pic]);
+
+        assert_eq!(allowed.len(), 1);
+        assert!(rejected.is_empty());
+    }
+
+    #[test]
+    fn rejects_traversal_above_the_document_tree() {
+        let dir = scratch();
+        let doc = dir.join("notes").join("note.md");
+        touch(&doc);
+        let secret = touch(&dir.join("secret.txt"));
+        // Exactly what `![x](../secret.txt)` resolves to in the renderer.
+        let traversal = s(&dir.join("notes").join("..").join("secret.txt"));
+
+        let (allowed, rejected) = partition_assets(&doc, &[], &[secret.clone(), traversal.clone()]);
+
+        assert!(allowed.is_empty());
+        assert_eq!(rejected, vec![secret, traversal]);
+    }
+
+    #[test]
+    fn widens_to_the_enclosing_git_checkout_but_no_further() {
+        let dir = scratch();
+        let repo = dir.join("repo");
+        fs::create_dir_all(repo.join(".git")).unwrap();
+        let doc = repo.join("docs").join("guide.md");
+        touch(&doc);
+        let inside = touch(&repo.join("assets").join("diagram.png"));
+        let above = touch(&dir.join("outside.png"));
+
+        let (allowed, rejected) = partition_assets(&doc, &[], &[inside.clone(), above.clone()]);
+
+        assert_eq!(allowed, vec![fs::canonicalize(&inside).unwrap()]);
+        assert_eq!(rejected, vec![above]);
+    }
+
+    #[test]
+    fn a_git_file_marks_a_checkout_too() {
+        // Worktrees and submodules keep a `.git` *file*, not a directory.
+        let dir = scratch();
+        let repo = dir.join("wt");
+        touch(&repo.join(".git"));
+        let doc = repo.join("docs").join("guide.md");
+        touch(&doc);
+        let inside = touch(&repo.join("assets").join("diagram.png"));
+
+        let (allowed, _) = partition_assets(&doc, &[], &[inside]);
+
+        assert_eq!(allowed.len(), 1);
+    }
+
+    #[test]
+    fn a_pinned_folder_is_an_allowed_root() {
+        let dir = scratch();
+        let doc = dir.join("notes").join("note.md");
+        touch(&doc);
+        let shared = touch(&dir.join("attachments").join("pic.png"));
+
+        let (allowed, rejected) = partition_assets(&doc, &[], &[shared.clone()]);
+        assert!(allowed.is_empty());
+        assert_eq!(rejected, vec![shared.clone()]);
+
+        let pinned = vec![s(&dir.join("attachments"))];
+        let (allowed, rejected) = partition_assets(&doc, &pinned, &[shared]);
+        assert_eq!(allowed.len(), 1);
+        assert!(rejected.is_empty());
+    }
+
+    #[test]
+    fn a_pinned_folder_does_not_match_by_string_prefix() {
+        let dir = scratch();
+        let doc = dir.join("elsewhere").join("note.md");
+        touch(&doc);
+        let pic = touch(&dir.join("attachments-private").join("pic.png"));
+
+        let pinned = vec![s(&dir.join("attachments"))];
+        fs::create_dir_all(dir.join("attachments")).unwrap();
+        let (allowed, rejected) = partition_assets(&doc, &pinned, &[pic.clone()]);
+
+        assert!(allowed.is_empty());
+        assert_eq!(rejected, vec![pic]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_a_symlink_that_escapes_the_tree() {
+        let dir = scratch();
+        let doc = dir.join("notes").join("note.md");
+        touch(&doc);
+        let secret = dir.join("secret.txt");
+        touch(&secret);
+        let link = dir.join("notes").join("innocent.png");
+        std::os::unix::fs::symlink(&secret, &link).unwrap();
+
+        let (allowed, rejected) = partition_assets(&doc, &[], &[s(&link)]);
+
+        assert!(allowed.is_empty());
+        assert_eq!(rejected, vec![s(&link)]);
+    }
+
+    #[test]
+    fn rejects_missing_files_and_directories() {
+        let dir = scratch();
+        let doc = dir.join("note.md");
+        touch(&doc);
+        fs::create_dir_all(dir.join("folder")).unwrap();
+        let missing = s(&dir.join("nope.png"));
+        let folder = s(&dir.join("folder"));
+
+        let (allowed, rejected) = partition_assets(&doc, &[], &[missing.clone(), folder.clone()]);
+
+        assert!(allowed.is_empty());
+        assert_eq!(rejected, vec![missing, folder]);
+    }
+
+    #[test]
+    fn a_document_that_is_not_on_disk_gets_only_pinned_roots() {
+        let dir = scratch();
+        let pic = touch(&dir.join("pic.png"));
+        let doc = Path::new("paste://1");
+
+        let (allowed, rejected) = partition_assets(doc, &[], &[pic.clone()]);
+        assert!(allowed.is_empty());
+        assert_eq!(rejected, vec![pic.clone()]);
+
+        let (allowed, _) = partition_assets(doc, &[s(&dir)], &[pic]);
+        assert_eq!(allowed.len(), 1);
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -26,7 +26,7 @@
         "enable": true,
         "scope": {
           "requireLiteralLeadingDot": false,
-          "allow": ["$HOME/**/*"]
+          "allow": []
         }
       }
     }

--- a/src/lib/renderer/pipeline.ts
+++ b/src/lib/renderer/pipeline.ts
@@ -67,9 +67,9 @@ export interface RenderResult {
   /**
    * Absolute on-disk paths of every local image the document references, after
    * resolution against `baseDir`. The caller hands these to the `allow_assets`
-   * command so the webview's asset protocol will actually serve them — files
-   * outside the static `$HOME/**` scope (external drives, /tmp, repos elsewhere)
-   * are otherwise refused (issue #31).
+   * command, which is the only way a file becomes fetchable by the webview's
+   * asset protocol (issue #31) — and which serves only files inside the
+   * document's own folder tree or a pinned folder, whatever this list says.
    */
   assetPaths: string[];
   /** True when the frontmatter declares `marp: true` — a Marp slide deck (#44). */

--- a/src/lib/tauri/files.ts
+++ b/src/lib/tauri/files.ts
@@ -1,10 +1,12 @@
 import { invoke } from "@tauri-apps/api/core";
+import { get } from "svelte/store";
 import { open, save } from "@tauri-apps/plugin-dialog";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { document } from "../stores/document";
 import { tabStore } from "../stores/tabs";
 import { renderFull } from "../renderer/pipeline";
 import { addRecentFile } from "../stores/recents";
+import { pinnedFolders } from "../stores/pinned";
 import { basename } from "../utils/path";
 
 export async function readMarkdownFile(path: string): Promise<string> {
@@ -37,7 +39,7 @@ export async function openFile(path: string): Promise<void> {
 
     // Whitelist the document's local images with the asset protocol before the
     // HTML hits the DOM, so images outside the static $HOME scope load (#31).
-    await allowAssets(result.assetPaths);
+    await allowAssets(result.assetPaths, absolutePath);
 
     const tabId = tabStore.addTab(absolutePath, fileName, content, result.html, result.frontmatter, result.wordCount);
 
@@ -146,7 +148,7 @@ export async function reloadCurrentFile(path: string): Promise<void> {
     const result = renderFull(content, baseDir);
     const fileName = basename(absolutePath);
 
-    await allowAssets(result.assetPaths);
+    await allowAssets(result.assetPaths, absolutePath);
 
     tabStore.updateTabContent(absolutePath, content, result.html, result.frontmatter, result.wordCount);
 
@@ -187,12 +189,27 @@ export async function openWithSystem(path: string): Promise<void> {
 }
 
 /**
- * Whitelist resolved local image paths with the webview's asset protocol so
- * they can be fetched regardless of the static $HOME scope (issue #31). A
- * failure here must not block text rendering — a broken image is acceptable
- * degradation, a blank document is not — so it's swallowed.
+ * Whitelist a document's resolved local image paths with the webview's asset
+ * protocol (issue #31). The Rust side serves only files inside the document's
+ * own folder tree (its git checkout, if it is in one) or a pinned folder — see
+ * `allow_assets` in commands.rs — and hands back whatever it refused, which is
+ * logged so a broken image is diagnosable. A failure here must not block text
+ * rendering — a broken image is acceptable degradation, a blank document is
+ * not — so errors are swallowed.
  */
-export async function allowAssets(paths: string[]): Promise<void> {
+export async function allowAssets(paths: string[], documentPath: string): Promise<void> {
   if (paths.length === 0) return;
-  await invoke("allow_assets", { paths }).catch(() => {});
+  try {
+    const rejected = await invoke<string[]>("allow_assets", {
+      documentPath,
+      pinnedFolders: get(pinnedFolders),
+      paths,
+    });
+    if (rejected.length > 0) {
+      console.warn(
+        `MDHero will not serve ${rejected.length} image(s) outside the document's folder tree. Pin the folder they live in to allow them:`,
+        rejected
+      );
+    }
+  } catch {}
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -189,7 +189,7 @@
     clearTimeout(splitPreviewTimer);
     splitPreviewTimer = setTimeout(() => {
       const result = renderFull(content, baseDir);
-      allowAssets(result.assetPaths);
+      allowAssets(result.assetPaths, activeTab.filePath);
       splitPreviewHtml = result.html;
     }, 120);
     return () => clearTimeout(splitPreviewTimer);
@@ -243,7 +243,7 @@
         // Fire-and-forget: referenced images were almost always allowed at open;
         // a brand-new external image typed mid-edit self-heals on the next
         // render/reload. Not worth making this sync path async (#31).
-        allowAssets(result.assetPaths);
+        allowAssets(result.assetPaths, activeTab.filePath);
         // Update the rendered HTML in the docStore so the viewer reflects
         // the unsaved edits. We do NOT call tabStore.updateTabContent or
         // markSaved — the source on disk is unchanged, dirty stays true.
@@ -290,7 +290,7 @@
       }
       const baseDir = getBaseDir(targetPath);
       const result = renderFull(tab.editContent, baseDir);
-      await allowAssets(result.assetPaths);
+      await allowAssets(result.assetPaths, targetPath);
       tabStore.markSaved(tab.id);
       tabStore.updateTabContent(
         targetPath,

--- a/tests/unit/allow-assets.test.ts
+++ b/tests/unit/allow-assets.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const invoke = vi.fn();
+const pinned = ["/vault/attachments"];
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke }));
+vi.mock("@tauri-apps/plugin-dialog", () => ({ open: vi.fn(), save: vi.fn() }));
+vi.mock("@tauri-apps/api/window", () => ({ getCurrentWindow: vi.fn() }));
+vi.mock("../../src/lib/stores/pinned", () => ({
+  pinnedFolders: { subscribe: (run: (v: string[]) => void) => (run(pinned), () => {}) },
+}));
+vi.mock("../../src/lib/stores/recents", () => ({ addRecentFile: vi.fn() }));
+
+const { allowAssets } = await import("../../src/lib/tauri/files");
+
+// The Rust command decides what the webview may fetch; this side's job is to
+// tell it which document is asking and which folders the user trusts, and to
+// make a refusal visible instead of silent (L10).
+describe("allowAssets", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    invoke.mockResolvedValue([]);
+  });
+
+  it("sends the document path and the pinned folders alongside the image paths", async () => {
+    await allowAssets(["/repo/assets/a.png", "/repo/docs/b.png"], "/repo/docs/guide.md");
+
+    expect(invoke).toHaveBeenCalledWith("allow_assets", {
+      documentPath: "/repo/docs/guide.md",
+      pinnedFolders: ["/vault/attachments"],
+      paths: ["/repo/assets/a.png", "/repo/docs/b.png"],
+    });
+  });
+
+  it("does not round-trip when the document references no local images", async () => {
+    await allowAssets([], "/repo/docs/guide.md");
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it("warns with the paths the backend refused to serve", async () => {
+    invoke.mockResolvedValue(["/etc/passwd"]);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await allowAssets(["/etc/passwd"], "/repo/docs/guide.md");
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][1]).toEqual(["/etc/passwd"]);
+    warn.mockRestore();
+  });
+
+  it("swallows a backend failure so the document still renders", async () => {
+    invoke.mockRejectedValue(new Error("boom"));
+    await expect(allowAssets(["/x.png"], "/repo/x.md")).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes the `allow_assets` gap found while reviewing #90 (tracked locally as L10). This is a security hardening change with one deliberate behaviour change, described below.

## What was wrong

Any markdown file could make any readable file on disk fetchable by the webview. `allow_assets` called `scope.allow_file` on every resolved `<img src>` with no check, so `![x](../../../.ssh/id_rsa)` widened the asset scope to that file. Separately, the static scope in `tauri.conf.json` was `$HOME/**/*` with dotfiles allowed, so everything under the home directory was fetchable without even asking. With `csp` null, DOMPurify was the only layer between a document and a disk-wide read primitive. #90 made the runtime path live on Windows too.

## What changes

The Rust side now decides what may be served. Each requested path is canonicalized (a symlink cannot smuggle a file in), must be a regular file, and must sit inside one of the document's asset roots:

- the directory the document lives in, widened to the enclosing git checkout when there is one, because `docs/guide.md` referencing `../assets/diagram.png` is how repositories are laid out;
- any folder the user has pinned in the sidebar, which is an explicit act of trust and the escape hatch for vaults that keep attachments beside the notes tree.

The static `$HOME/**/*` scope is removed. The only files the webview can ever fetch are the ones a document legitimately referenced from its own tree. Refused paths are returned to the frontend and logged with a hint to pin the folder, so a broken image is diagnosable instead of silent.

## Behaviour change

A document that references an image by absolute path elsewhere under `$HOME`, or via `..` above its git root, now shows a broken image unless that folder is pinned. This matches what #31 asked for ("only directories the user actually opened"); the implementation that shipped drifted from it.

## Evidence

- 10 Rust unit tests on the pure `partition_assets`: image beside the document, in a subfolder, traversal above the tree, git-root widening and its limit, `.git` as a file (worktrees/submodules), pinned root, no string-prefix match on pinned roots, escaping symlink, missing file and directory, document not on disk. Removing the containment check turns 6 of them red.
- 4 vitest cases on `allowAssets`: payload shape, no round-trip on empty, warning on refusal, backend failure swallowed. Suite: 54/54.
- Smoked in the debug app on a fixture repo under `/tmp`: images beside the document and one level up inside the checkout render; above the git root, an absolute path into `$HOME`, and `../..` to `~/.ssh/config` are refused.

Not in this PR: a CSP. That is the other missing layer and deserves its own change, since it interacts with KaTeX fonts, mermaid and inline styles.
