### PR TITLE
feat: restore open tabs after a restart

### DIFF
--- a/src/lib/components/SettingsDialog.svelte
+++ b/src/lib/components/SettingsDialog.svelte
@@ -47,6 +47,19 @@
 
           <label class="setting-row">
             <div class="setting-text">
+              <span class="setting-label">Restore tabs on launch</span>
+              <span class="setting-hint">Reopen the files that were open last time, in the same order.</span>
+            </div>
+            <input
+              type="checkbox"
+              checked={$settings.restoreTabsOnLaunch}
+              onchange={(e) => settings.update((s) => ({ ...s, restoreTabsOnLaunch: e.currentTarget.checked }))}
+              class="setting-switch"
+            />
+          </label>
+
+          <label class="setting-row">
+            <div class="setting-text">
               <span class="setting-label">Auto-present Marp decks</span>
               <span class="setting-hint">Open documents with <code>marp: true</code> frontmatter as a slideshow.</span>
             </div>

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -10,6 +10,8 @@ export interface ReaderSettings {
   showLineNumbers: boolean;
   /** Auto-open `marp: true` documents as a slideshow (#44). */
   autoPresentMarp: boolean;
+  /** Reopen the files that were open when the app last ran (#72). */
+  restoreTabsOnLaunch: boolean;
 }
 
 const STORAGE_KEY = "mdhero-settings";
@@ -32,6 +34,7 @@ function loadSettings(): ReaderSettings {
     closeOnEscape: true,
     showLineNumbers: true,
     autoPresentMarp: true,
+    restoreTabsOnLaunch: true,
   };
 
   if (typeof localStorage === "undefined") return defaults;

--- a/src/lib/stores/tabs.ts
+++ b/src/lib/stores/tabs.ts
@@ -17,9 +17,72 @@ export interface Tab {
 
 export const HOME_TAB_ID = "__home__";
 
+/**
+ * What survives a restart (#72): the on-disk files that were open, in tab
+ * order, and which of them was active (`null` when the home tab was). Nothing
+ * else — unsaved edits, scroll offsets and the `paste://` / `url://` / `new://`
+ * tabs have no file to come back from.
+ */
+export interface SavedSession {
+  paths: string[];
+  activePath: string | null;
+}
+
+const SESSION_KEY = "mdhero-session";
+
+function isRestorablePath(filePath: string): boolean {
+  return !!filePath
+    && !filePath.startsWith("paste://")
+    && !filePath.startsWith("url://")
+    && !filePath.startsWith("new://");
+}
+
+function loadSession(): SavedSession | null {
+  if (typeof localStorage === "undefined") return null;
+  try {
+    const raw = localStorage.getItem(SESSION_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed?.paths)) return null;
+    return {
+      paths: parsed.paths.filter((p: unknown) => typeof p === "string" && isRestorablePath(p)),
+      activePath: typeof parsed.activePath === "string" ? parsed.activePath : null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function saveSession(session: SavedSession) {
+  if (typeof localStorage === "undefined") return;
+  try {
+    localStorage.setItem(SESSION_KEY, JSON.stringify(session));
+  } catch {}
+}
+
 function createTabStore() {
   const tabs = writable<Tab[]>([]);
   const activeTabId = writable<string | null>(HOME_TAB_ID);
+
+  // Captured once, before the persistence subscription below overwrites the
+  // key with this (empty) session. `restoreSession` reads it on launch.
+  const savedSession = loadSession();
+
+  function persistSession() {
+    const currentTabs = get(tabs);
+    const active = currentTabs.find((t) => t.id === get(activeTabId));
+    saveSession({
+      paths: currentTabs.filter((t) => isRestorablePath(t.filePath)).map((t) => t.filePath),
+      activePath: active && isRestorablePath(active.filePath) ? active.filePath : null,
+    });
+  }
+  tabs.subscribe(persistSession);
+  activeTabId.subscribe(persistSession);
+
+  /** The session as it was when this store initialised — i.e. the previous run's. */
+  function getSavedSession(): SavedSession | null {
+    return savedSession;
+  }
 
   function generateId(): string {
     return Math.random().toString(36).slice(2, 10);
@@ -207,6 +270,7 @@ function createTabStore() {
     getLastSavedAt,
     rebindPath,
     saveScrollPosition,
+    getSavedSession,
   };
 }
 

--- a/src/lib/tauri/session.ts
+++ b/src/lib/tauri/session.ts
@@ -1,0 +1,36 @@
+import { get } from "svelte/store";
+import { tabStore } from "../stores/tabs";
+import { openFile, pathExists } from "./files";
+
+/**
+ * Reopen the previous run's tabs (#72): same files, same order, same active
+ * tab. Files that no longer exist are skipped silently, and a file that fails
+ * to open does not stop the rest. Returns how many tabs came back.
+ *
+ * Runs before any "Open With" / CLI file so that one lands on top, active, the
+ * way a browser handles a link clicked while it restores a session.
+ */
+export async function restoreSession(): Promise<number> {
+  const saved = tabStore.getSavedSession();
+  if (!saved || saved.paths.length === 0) return 0;
+
+  let restored = 0;
+  for (const path of saved.paths) {
+    try {
+      if (!(await pathExists(path))) continue;
+      await openFile(path);
+      restored++;
+    } catch {}
+  }
+  if (restored === 0) return 0;
+
+  const tabs = get(tabStore.tabs);
+  const active = saved.activePath ? tabs.find((t) => t.filePath === saved.activePath) : undefined;
+  if (active) {
+    tabStore.switchTab(active.id);
+  } else if (saved.activePath === null) {
+    tabStore.goHome();
+  }
+  // Else: the active file is gone; stay on the last one that came back.
+  return restored;
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -18,6 +18,7 @@
   import { basename } from "$lib/utils/path";
   import { settings, getContentMaxWidth } from "$lib/stores/settings";
   import { startFileWatcher, stopFileWatcher } from "$lib/tauri/watcher";
+  import { restoreSession } from "$lib/tauri/session";
   import { themeMode, cycleTheme } from "$lib/stores/theme";
   import { getCurrentWindow } from "@tauri-apps/api/window";
   import { invoke } from "@tauri-apps/api/core";
@@ -604,6 +605,14 @@
     document.addEventListener("visibilitychange", handleVisibilityChange);
 
     void (async () => {
+      // Bring back last run's tabs first (#72), so a file opened via "Open
+      // With" or the CLI below lands on top of them as the active tab.
+      if ($settings.restoreTabsOnLaunch) {
+        try {
+          await restoreSession();
+        } catch {}
+      }
+
       // Check for files opened via "Open With" / double-click (buffered in Rust state)
       try {
         const { invoke } = await import("@tauri-apps/api/core");

--- a/tests/unit/session-restore.test.ts
+++ b/tests/unit/session-restore.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const openFile = vi.fn();
+const pathExists = vi.fn();
+const switchTab = vi.fn();
+const goHome = vi.fn();
+let saved: { paths: string[]; activePath: string | null } | null = null;
+let tabs: { id: string; filePath: string }[] = [];
+
+vi.mock("../../src/lib/tauri/files", () => ({ openFile, pathExists }));
+vi.mock("../../src/lib/stores/tabs", () => ({
+  tabStore: {
+    getSavedSession: () => saved,
+    tabs: { subscribe: (run: (v: unknown) => void) => (run(tabs), () => {}) },
+    switchTab,
+    goHome,
+  },
+}));
+
+const { restoreSession } = await import("../../src/lib/tauri/session");
+
+describe("restoreSession (#72)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    pathExists.mockResolvedValue(true);
+    openFile.mockImplementation(async (p: string) => {
+      tabs = [...tabs, { id: `id:${p}`, filePath: p }];
+    });
+    tabs = [];
+    saved = null;
+  });
+
+  it("does nothing when there is no saved session", async () => {
+    expect(await restoreSession()).toBe(0);
+    expect(openFile).not.toHaveBeenCalled();
+  });
+
+  it("reopens the files in their saved order and re-activates the saved tab", async () => {
+    saved = { paths: ["/d/a.md", "/d/b.md", "/d/c.md"], activePath: "/d/b.md" };
+
+    expect(await restoreSession()).toBe(3);
+    expect(openFile.mock.calls.map((c) => c[0])).toEqual(["/d/a.md", "/d/b.md", "/d/c.md"]);
+    expect(switchTab).toHaveBeenCalledWith("id:/d/b.md");
+    expect(goHome).not.toHaveBeenCalled();
+  });
+
+  it("skips files that no longer exist without touching the rest", async () => {
+    saved = { paths: ["/d/a.md", "/d/gone.md", "/d/c.md"], activePath: "/d/gone.md" };
+    pathExists.mockImplementation(async (p: string) => p !== "/d/gone.md");
+
+    expect(await restoreSession()).toBe(2);
+    expect(openFile.mock.calls.map((c) => c[0])).toEqual(["/d/a.md", "/d/c.md"]);
+    // The active file is gone: stay on the last one that came back.
+    expect(switchTab).not.toHaveBeenCalled();
+    expect(goHome).not.toHaveBeenCalled();
+  });
+
+  it("returns to the home tab when that is where the user was", async () => {
+    saved = { paths: ["/d/a.md"], activePath: null };
+
+    await restoreSession();
+    expect(goHome).toHaveBeenCalledTimes(1);
+  });
+
+  it("carries on when one file fails to open", async () => {
+    saved = { paths: ["/d/a.md", "/d/bad.md", "/d/c.md"], activePath: "/d/c.md" };
+    openFile.mockImplementation(async (p: string) => {
+      if (p === "/d/bad.md") throw new Error("boom");
+      tabs = [...tabs, { id: `id:${p}`, filePath: p }];
+    });
+
+    expect(await restoreSession()).toBe(2);
+    expect(switchTab).toHaveBeenCalledWith("id:/d/c.md");
+  });
+});

--- a/tests/unit/tabs-session.test.ts
+++ b/tests/unit/tabs-session.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// The tab store persists a restorable session on every change (#72). These
+// tests run it against a fake localStorage and read the key back directly.
+const SESSION_KEY = "mdhero-session";
+
+function fakeStorage(initial: Record<string, string> = {}) {
+  const map = new Map(Object.entries(initial));
+  return {
+    getItem: (k: string) => map.get(k) ?? null,
+    setItem: (k: string, v: string) => void map.set(k, v),
+    removeItem: (k: string) => void map.delete(k),
+    clear: () => map.clear(),
+  };
+}
+
+async function freshStore(initial: Record<string, string> = {}) {
+  vi.resetModules();
+  (globalThis as any).localStorage = fakeStorage(initial);
+  (globalThis as any).window = { scrollY: 0 };
+  const mod = await import("../../src/lib/stores/tabs");
+  return mod.tabStore;
+}
+
+function session() {
+  return JSON.parse((globalThis as any).localStorage.getItem(SESSION_KEY));
+}
+
+describe("tab session persistence", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("records on-disk tabs in order and which one is active", async () => {
+    const store = await freshStore();
+    store.addTab("/docs/a.md", "a.md", "", "");
+    store.addTab("/docs/b.md", "b.md", "", "");
+    store.addTab("/docs/c.md", "c.md", "", "");
+    store.switchTab(store.getActiveTab()!.id); // no-op switch keeps c active
+
+    expect(session()).toEqual({ paths: ["/docs/a.md", "/docs/b.md", "/docs/c.md"], activePath: "/docs/c.md" });
+  });
+
+  it("leaves out tabs that have no file to come back from", async () => {
+    const store = await freshStore();
+    store.addTab("/docs/a.md", "a.md", "", "");
+    store.addTab("paste://1", "Pasted", "", "");
+    store.addTab("url://https://example.com/x.md", "x.md", "", "");
+    store.addTab("new://2", "Untitled", "", "");
+
+    expect(session()).toEqual({ paths: ["/docs/a.md"], activePath: null });
+  });
+
+  it("records the home tab as no active file", async () => {
+    const store = await freshStore();
+    store.addTab("/docs/a.md", "a.md", "", "");
+    store.goHome();
+
+    expect(session().activePath).toBeNull();
+    expect(session().paths).toEqual(["/docs/a.md"]);
+  });
+
+  it("follows closes and reorders", async () => {
+    const store = await freshStore();
+    store.addTab("/docs/a.md", "a.md", "", "");
+    const b = store.addTab("/docs/b.md", "b.md", "", "");
+    store.addTab("/docs/c.md", "c.md", "", "");
+
+    store.reorderTabs(2, 0);
+    expect(session().paths).toEqual(["/docs/c.md", "/docs/a.md", "/docs/b.md"]);
+
+    store.closeTab(b);
+    expect(session()).toEqual({ paths: ["/docs/c.md", "/docs/a.md"], activePath: "/docs/c.md" });
+  });
+
+  it("makes a new document restorable once it is saved to a path", async () => {
+    const store = await freshStore();
+    const id = store.addTab("new://1", "Untitled", "", "");
+    expect(session().paths).toEqual([]);
+
+    store.rebindPath(id, "/docs/saved.md", "saved.md");
+    expect(session()).toEqual({ paths: ["/docs/saved.md"], activePath: "/docs/saved.md" });
+  });
+
+  it("hands back the previous run's session, not the empty one it just wrote", async () => {
+    const store = await freshStore({
+      [SESSION_KEY]: JSON.stringify({ paths: ["/docs/old.md", "paste://9"], activePath: "/docs/old.md" }),
+    });
+
+    // The store's own persistence has already overwritten the key on init...
+    expect(session()).toEqual({ paths: [], activePath: null });
+    // ...but the captured copy is what restoreSession needs, sentinels dropped.
+    expect(store.getSavedSession()).toEqual({ paths: ["/docs/old.md"], activePath: "/docs/old.md" });
+  });
+
+  it("treats a corrupt or missing session as nothing to restore", async () => {
+    expect((await freshStore({ [SESSION_KEY]: "{not json" })).getSavedSession()).toBeNull();
+    expect((await freshStore({ [SESSION_KEY]: JSON.stringify({ nope: 1 }) })).getSavedSession()).toBeNull();
+    expect((await freshStore()).getSavedSession()).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #72.

## What changes

The tab store now writes a small session to localStorage on every change: the on-disk files that are open, in tab order, and which one is active (or the home tab). On launch, those files are reopened in the same order, files that no longer exist are skipped, and the previously active tab is re-activated. Every other store already persisted this way; tabs were the one gap.

`paste://`, `url://` and unsaved new-document tabs are not part of the session, since they have no file to come back from. A new document joins the session the moment it is saved to a path. Unsaved edits and scroll offsets are not restored either; reading progress already brings back the scroll position per file.

Restore runs before any "Open With" or CLI file, so that file lands on top as the active tab, the way a browser treats a link clicked during session restore.

A new **Restore tabs on launch** setting (default on) turns it off.

## Evidence

- 7 unit tests on persistence: order and active tab, sentinels excluded, home tab, close and reorder, a saved new document becoming restorable, the previous run's session surviving the store's own first write, corrupt data. Removing the store subscriptions turns 6 of them red.
- 5 unit tests on restore: no session, order plus active, missing files skipped without disturbing the rest, home tab, one file failing to open. Suite 66/66, types clean.
- Smoked in the debug app across five launches: open A; open B (A restored beside it); no arguments (A, B, B active); open a temp file; delete it and relaunch (A, B, no error, last restored tab active).
