### PR TITLE
fix: honour <div dir> wrappers and align RTL table cells

### DIFF
--- a/src/lib/components/MarkdownRenderer.svelte
+++ b/src/lib/components/MarkdownRenderer.svelte
@@ -412,7 +412,7 @@
   article :global(td) {
     border: 1px solid #e5e5ea;
     padding: 0.5em 0.75em;
-    text-align: left;
+    text-align: start;
   }
 
   :global(html.dark) article :global(th),

--- a/src/lib/renderer/pipeline.ts
+++ b/src/lib/renderer/pipeline.ts
@@ -127,20 +127,61 @@ const DIR_AUTO_BLOCKS = new Set([
   "th_open",
 ]);
 
+// A paragraph whose whole content is `<div dir="rtl">` / `<div dir="ltr">` (any
+// other attributes tolerated and ignored) or `</div>`. Raw HTML is disabled in
+// the renderer, so these arrive as ordinary paragraphs of text; we recognise
+// exactly these two shapes and nothing else.
+const DIR_WRAPPER_OPEN = /^<div(?:\s+[^>]*?)?\sdir\s*=\s*["']?(rtl|ltr)["']?(?:\s[^>]*)?>$/i;
+const DIR_WRAPPER_CLOSE = /^<\/div\s*>$/i;
+
 /**
- * Stamp `dir="auto"` on each text-bearing block so it picks its own base
- * direction from its first strong-directional character — RTL paragraphs
- * (Hebrew/Arabic) then right-align on their own, like the browser and VSCode,
- * without forcing a whole-document direction (#64). Mixed LTR/RTL docs resolve
- * per block. `dir` is a standard global attribute, so DOMPurify keeps it.
+ * Give each text-bearing block a direction (#64, #95).
+ *
+ * By default that is `dir="auto"`: the block picks its own base direction from
+ * its first strong-directional character, so RTL paragraphs (Hebrew/Arabic)
+ * right-align on their own, like the browser and VSCode, without forcing a
+ * whole-document direction. Mixed LTR/RTL docs resolve per block.
+ *
+ * Authors of RTL documents also write `<div dir="rtl">` … `</div>` around
+ * sections, the way GitHub renders them. Raw HTML stays off in this renderer,
+ * so those lines would otherwise print as literal text; instead a paragraph
+ * that is exactly such a wrapper line is dropped and every block inside gets
+ * that explicit direction. That also covers what `auto` gets wrong on its own —
+ * a Persian paragraph beginning with a product name or a number. Nothing else
+ * about HTML changes. `dir` is a standard global attribute, so DOMPurify keeps
+ * it. A `</div>` with no open wrapper stays as text.
  */
-function addDirAutoPlugin(mdInstance: MarkdownIt) {
-  mdInstance.core.ruler.push("dir-auto", (state) => {
-    for (const token of state.tokens) {
-      if (DIR_AUTO_BLOCKS.has(token.type)) {
-        token.attrSet("dir", "auto");
+function addDirPlugin(mdInstance: MarkdownIt) {
+  mdInstance.core.ruler.push("dir", (state) => {
+    const tokens = state.tokens;
+    const kept: typeof tokens = [];
+    const stack: string[] = [];
+    for (let i = 0; i < tokens.length; i++) {
+      const token = tokens[i];
+      if (
+        token.type === "paragraph_open" &&
+        tokens[i + 1]?.type === "inline" &&
+        tokens[i + 2]?.type === "paragraph_close"
+      ) {
+        const content = tokens[i + 1].content.trim();
+        const open = content.match(DIR_WRAPPER_OPEN);
+        if (open) {
+          stack.push(open[1].toLowerCase());
+          i += 2;
+          continue;
+        }
+        if (stack.length > 0 && DIR_WRAPPER_CLOSE.test(content)) {
+          stack.pop();
+          i += 2;
+          continue;
+        }
       }
+      if (DIR_AUTO_BLOCKS.has(token.type)) {
+        token.attrSet("dir", stack.length > 0 ? stack[stack.length - 1] : "auto");
+      }
+      kept.push(token);
     }
+    state.tokens = kept;
   });
 }
 
@@ -180,7 +221,7 @@ export async function initRenderer(): Promise<void> {
         .replace(/\s+/g, "-"),
   });
   addSourceLinePlugin(md);
-  addDirAutoPlugin(md);
+  addDirPlugin(md);
 
   initialized = true;
 }
@@ -215,7 +256,7 @@ export function renderFull(markdown: string, baseDir?: string): RenderResult {
       slugify: (s: string) => s.toLowerCase().trim().replace(/[^\w\s-]/g, "").replace(/\s+/g, "-"),
     });
     addSourceLinePlugin(md);
-    addDirAutoPlugin(md);
+    addDirPlugin(md);
     initialized = true;
   }
 

--- a/src/lib/renderer/pipeline.ts
+++ b/src/lib/renderer/pipeline.ts
@@ -131,8 +131,23 @@ const DIR_AUTO_BLOCKS = new Set([
 // other attributes tolerated and ignored) or `</div>`. Raw HTML is disabled in
 // the renderer, so these arrive as ordinary paragraphs of text; we recognise
 // exactly these two shapes and nothing else.
-const DIR_WRAPPER_OPEN = /^<div(?:\s+[^>]*?)?\sdir\s*=\s*["']?(rtl|ltr)["']?(?:\s[^>]*)?>$/i;
+//
+// Two guards keep this linear in the input, because the renderer runs on the
+// UI thread and a document is attacker-controlled: the tag shape is checked
+// with a pattern that has no overlapping quantifiers, and the `dir` value is
+// then read from the attribute text by a second bounded search. A wrapper line
+// is a few dozen characters, so anything longer is not even inspected.
+const DIR_WRAPPER_MAX_LEN = 256;
+const DIR_WRAPPER_TAG = /^<div(?:\s[^>]*)?>$/i;
+const DIR_WRAPPER_VALUE = /(?:^|\s)dir\s*=\s*["']?(rtl|ltr)["']?(?=\s|>|$)/i;
 const DIR_WRAPPER_CLOSE = /^<\/div\s*>$/i;
+
+/** "rtl" / "ltr" when `content` is exactly a direction wrapper line, else null. */
+function wrapperDirection(content: string): "rtl" | "ltr" | null {
+  if (content.length > DIR_WRAPPER_MAX_LEN || !DIR_WRAPPER_TAG.test(content)) return null;
+  const m = content.slice(4, -1).match(DIR_WRAPPER_VALUE);
+  return m ? (m[1].toLowerCase() as "rtl" | "ltr") : null;
+}
 
 /**
  * Give each text-bearing block a direction (#64, #95).
@@ -158,19 +173,27 @@ function addDirPlugin(mdInstance: MarkdownIt) {
     const stack: string[] = [];
     for (let i = 0; i < tokens.length; i++) {
       const token = tokens[i];
+      // A wrapper is a paragraph of its own. `hidden` paragraphs are the
+      // implicit ones inside tight list items; a `<div>` typed as a bullet is
+      // text, not a wrapper, so bullets never vanish.
       if (
         token.type === "paragraph_open" &&
+        !token.hidden &&
         tokens[i + 1]?.type === "inline" &&
         tokens[i + 2]?.type === "paragraph_close"
       ) {
         const content = tokens[i + 1].content.trim();
-        const open = content.match(DIR_WRAPPER_OPEN);
+        const open = wrapperDirection(content);
         if (open) {
-          stack.push(open[1].toLowerCase());
+          stack.push(open);
           i += 2;
           continue;
         }
-        if (stack.length > 0 && DIR_WRAPPER_CLOSE.test(content)) {
+        if (
+          stack.length > 0 &&
+          content.length <= DIR_WRAPPER_MAX_LEN &&
+          DIR_WRAPPER_CLOSE.test(content)
+        ) {
           stack.pop();
           i += 2;
           continue;

--- a/tests/unit/rtl-direction.test.ts
+++ b/tests/unit/rtl-direction.test.ts
@@ -38,3 +38,59 @@ describe("dir=auto for bidirectional text", () => {
     expect(html).not.toContain('<code dir="auto"');
   });
 });
+
+// #95: RTL authors wrap sections in `<div dir="rtl">` … `</div>` the way GitHub
+// renders them. Raw HTML stays off, so the renderer recognises exactly those
+// wrapper lines, drops them, and gives every block inside the explicit
+// direction — which also fixes what dir="auto" gets wrong on its own.
+describe("<div dir> wrapper lines (#95)", () => {
+  it("drops the wrapper lines and stamps the explicit direction inside", () => {
+    const html = render('<div dir="rtl">\n\n# سلام\n\nمتن.\n\n</div>\n\nAfter.');
+    expect(html).not.toContain("&lt;div");
+    expect(html).not.toContain("&lt;/div&gt;");
+    expect(html).toMatch(/<h1[^>]*\bdir="rtl"/);
+    expect(html).toMatch(/<p[^>]*\bdir="rtl"[^>]*>متن\./);
+    expect(html).toMatch(/<p[^>]*\bdir="auto"[^>]*>After\./);
+  });
+
+  it("tolerates other attributes in any order, as the reporter writes it", () => {
+    const a = render('<div dir="rtl" align="right">\n\nمتن.\n\n</div>');
+    const b = render("<div align='right' dir='rtl'>\n\nمتن.\n\n</div>");
+    for (const html of [a, b]) {
+      expect(html).not.toContain("&lt;div");
+      expect(html).toMatch(/<p[^>]*\bdir="rtl"/);
+    }
+  });
+
+  it("forces RTL on a paragraph that begins with a Latin word, which auto gets wrong", () => {
+    const html = render('<div dir="rtl">\n\nWindows 11 در این نسخه پشتیبانی می‌شود.\n\n</div>');
+    expect(html).toMatch(/<p[^>]*\bdir="rtl"[^>]*>Windows 11/);
+  });
+
+  it("applies to lists and table cells inside the wrapper", () => {
+    const html = render('<div dir="rtl">\n\n- یک\n\n| ستون |\n|---|\n| یک |\n\n</div>');
+    expect(html).toContain('<li dir="rtl"');
+    expect(html).toContain('<th dir="rtl"');
+    expect(html).toContain('<td dir="rtl"');
+  });
+
+  it("supports ltr wrappers and nesting, popping back to the outer direction", () => {
+    const html = render('<div dir="rtl">\n\nاول\n\n<div dir="ltr">\n\nEnglish inside.\n\n</div>\n\nدوم\n\n</div>');
+    expect(html).toMatch(/<p[^>]*\bdir="rtl"[^>]*>اول/);
+    expect(html).toMatch(/<p[^>]*\bdir="ltr"[^>]*>English inside\./);
+    expect(html).toMatch(/<p[^>]*\bdir="rtl"[^>]*>دوم/);
+  });
+
+  it("leaves a stray </div> and any other tag as text", () => {
+    expect(render("</div>")).toContain("&lt;/div&gt;");
+    expect(render('<div class="x">\n\nمتن.\n\n</div>')).toContain("&lt;div");
+    expect(render('<span dir="rtl">\n\nمتن.\n\n</span>')).toContain("&lt;span");
+  });
+
+  it("leaves code blocks LTR even inside an rtl wrapper", () => {
+    const html = render('<div dir="rtl">\n\n```\nconst x = 1;\n```\n\n</div>');
+    expect(html).not.toContain('<pre dir=');
+    expect(html).not.toContain('<code dir=');
+    expect(html).toContain("<pre><code>");
+  });
+});

--- a/tests/unit/rtl-direction.test.ts
+++ b/tests/unit/rtl-direction.test.ts
@@ -94,3 +94,41 @@ describe("<div dir> wrapper lines (#95)", () => {
     expect(html).toContain("<pre><code>");
   });
 });
+
+// Security review of the wrapper rule: a document is attacker-controlled and
+// the renderer runs on the UI thread.
+describe("<div dir> wrapper hardening", () => {
+  it("discards every other attribute on the wrapper — nothing from the tag reaches the output", () => {
+    const html = render('<div dir="rtl" onmouseover="alert(1)" style="position:fixed" id="x" class="y">\n\nمتن.\n\n</div>');
+    expect(html).toBe('<p dir="rtl">متن.</p>\n'.replace('<p', '<p data-source-line="2"'));
+    expect(html).not.toMatch(/onmouseover|style=|id="x"|class="y"/);
+  });
+
+  it("only ever emits dir=rtl or dir=ltr — a crafted value stays text", () => {
+    const html = render('<div dir="rtl\\" onclick=\\"alert(1)">\n\nمتن.\n\n</div>');
+    expect(html).toContain("&lt;div");
+    expect(html).not.toMatch(/<[a-z][^>]*onclick=/); // never on an element, only as escaped text
+    expect(html.match(/\bdir="([^"]*)"/g)!.every((a) => a === 'dir="auto"')).toBe(true);
+  });
+
+  it("does not treat a tight list bullet as a wrapper, so bullets never vanish", () => {
+    const html = render('- <div dir="rtl">\n- x\n- </div>');
+    expect(html).toContain("&lt;div");
+    expect(html).not.toContain("<li dir=\"rtl\"");
+    expect((html.match(/<li/g) ?? []).length).toBe(3);
+  });
+
+  it("matches in linear time — a 100k-character tag-shaped paragraph renders in milliseconds", () => {
+    const shapes = [
+      "<div" + " ".repeat(100_000) + "x>",
+      "<div" + " ".repeat(100_000) + " dir=xx>",
+      "<div " + "a=b ".repeat(25_000) + ">",
+      "</div" + " ".repeat(100_000) + ">",
+    ];
+    for (const s of shapes) {
+      const t = performance.now();
+      render(s + "\n\nx\n\n</div>");
+      expect(performance.now() - t).toBeLessThan(200);
+    }
+  });
+});


### PR DESCRIPTION
Closes #95. Follows #66, which gave every text block `dir="auto"` and ships in v0.2.9.

## What #66 left, and what this fixes

1. **`<div dir="rtl">` … `</div>` wrapper lines printed as literal text.** Authors of RTL documents write them the way GitHub renders them. Raw HTML is off in this renderer and stays off. Instead, a paragraph that is exactly such a wrapper line (`dir="rtl"` or `dir="ltr"`, other attributes tolerated and ignored) is dropped, and every block inside gets that explicit direction. Nesting pops back to the outer direction. A stray `</div>`, a `<div class>`, a `<span dir>` or any other tag stays as text.
2. **A Persian paragraph beginning with a Latin word or a number rendered left-to-right**, because `dir="auto"` follows the first strong character. Inside a wrapper the explicit direction replaces the heuristic, which is exactly what the wrapper is for.
3. **Table cells stayed left-aligned** even with `dir="auto"` on them, because `th, td` were styled `text-align: left`, which beats the direction-aware default. Now `text-align: start`.

## Security review

A document is attacker-controlled input and the renderer runs on the UI thread, so the wrapper rule was reviewed before this PR was opened. Nothing from the tag is ever copied to the output: the only attribute emitted is `dir`, with a value from a fixed two-item set. Probes for attribute injection (`onmouseover`, `style`, `id`, `class`), value injection, `<script>`, `<img onerror>` and `javascript:` links inside a wrapper, one-line tags, self-closing tags, junk on the closing tag, fullwidth look-alikes and deep nesting all come out as escaped text or a bare `dir` attribute. The DOMPurify config is untouched; `dir` is on its default allowlist.

The review found two defects in the first commit, fixed in the second: a regex denial of service (`<div` followed by 100k spaces took 2.9 s, quadratic; now a no-overlap match with a 256-character cap, 9 ms at 100k and 16 ms at 1M characters), and a `<div dir="rtl">` typed as a tight-list bullet being consumed and leaving an empty bullet (tight-list paragraphs are now skipped).

## Evidence

- 11 new tests in `tests/unit/rtl-direction.test.ts`: wrapper dropped and direction stamped, attributes in any order, Latin-first paragraph forced RTL, lists and cells inside, `ltr` and nesting, stray tags left as text, code stays LTR, other attributes discarded, crafted value stays text, tight-list bullet stays text, 100k-character tag-shaped paragraph renders in under 200 ms. Neutralising the wrapper match turns 5 of the first 11 red. Suite 77/77, types clean.
- Smoked in the debug app on a three-case fixture before and after: wrapper lines gone, the `Windows 11 …` line right-to-left, table cells right-aligned.

## Deliberate limits

- The wrapper must be on its own line with blank lines around it. That is how the reporter writes it, and the only form GitHub renders correctly too.
- `align="right"` is ignored; direction handles alignment.
- Only these two wrapper shapes are honoured. Everything else about HTML is unchanged.
