### PR TITLE
feat: sync editor and preview scrolling in split mode

### DIFF
--- a/src/lib/utils/scroll-sync.ts
+++ b/src/lib/utils/scroll-sync.ts
@@ -90,6 +90,47 @@ function lineOf(el: HTMLElement): number {
   return parseInt(el.getAttribute("data-source-line") || "0", 10);
 }
 
+// --- Rendered blocks inside a scroll container (split-mode preview, #74) ---
+//
+// Same anchoring as the viewer above, but relative to a container that scrolls
+// itself instead of the window, so the reference line is the container's top
+// edge rather than the sticky chrome.
+
+/** Fractional source line anchored at the top of `container`'s viewport. */
+export function readBlockLineIn(container: HTMLElement): number {
+  const top = container.getBoundingClientRect().top;
+  const elements = container.querySelectorAll<HTMLElement>("[data-source-line]");
+  if (elements.length === 0) return 0;
+  for (const el of elements) {
+    const rect = el.getBoundingClientRect();
+    if (rect.bottom > top) {
+      const frac = rect.height > 0 ? clamp01((top - rect.top) / rect.height) : 0;
+      return lineOf(el) + frac;
+    }
+  }
+  return lineOf(elements[elements.length - 1]);
+}
+
+/** Scroll `container` so the block holding fractional `anchor` sits at its top. */
+export function scrollBlocksToLineIn(container: HTMLElement, anchor: number): void {
+  if (anchor <= 0) {
+    container.scrollTop = 0;
+    return;
+  }
+  const elements = Array.from(container.querySelectorAll<HTMLElement>("[data-source-line]"));
+  if (elements.length === 0) return;
+  const floor = Math.floor(anchor);
+  const frac = anchor - floor;
+  let target = elements[0];
+  for (const el of elements) {
+    if (lineOf(el) <= floor) target = el;
+    else break;
+  }
+  const rect = target.getBoundingClientRect();
+  const top = container.getBoundingClientRect().top;
+  container.scrollTop += rect.top - top + frac * rect.height;
+}
+
 // --- Raw (window-scrolled <pre class="raw-source">) ---
 
 function readRawLine(): number {
@@ -136,7 +177,7 @@ function scrollEditorToLine(anchor: number): void {
 // line's wrapped rows (0 = line top, →1 = next line top). The fraction is what
 // preserves position inside a tall block across a mode switch (issue #21).
 
-function clamp01(x: number): number {
+export function clamp01(x: number): number {
   return x < 0 ? 0 : x > 1 ? 1 : x;
 }
 
@@ -146,7 +187,7 @@ function clampLine(line: number, count: number): number {
 }
 
 /** Largest index `i` with `offsets[i] <= y` (binary search). */
-function lineAtOffset(offsets: number[], y: number): number {
+export function lineAtOffset(offsets: number[], y: number): number {
   if (offsets.length === 0 || y <= 0) return 0;
   let lo = 0;
   let hi = offsets.length - 1;
@@ -164,7 +205,7 @@ function lineAtOffset(offsets: number[], y: number): number {
 }
 
 /** Fractional source line at pixel `y`: integer line + fraction into its rows. */
-function fractionalLineAtOffset(offsets: number[], y: number): number {
+export function fractionalLineAtOffset(offsets: number[], y: number): number {
   if (offsets.length === 0 || y <= 0) return 0;
   const floor = lineAtOffset(offsets, y);
   const base = offsets[floor];
@@ -174,7 +215,7 @@ function fractionalLineAtOffset(offsets: number[], y: number): number {
 }
 
 /** Inverse of `fractionalLineAtOffset`: pixel offset for a fractional line. */
-function pixelAtLine(offsets: number[], anchor: number): number {
+export function pixelAtLine(offsets: number[], anchor: number): number {
   if (offsets.length === 0) return 0;
   const floor = clampLine(Math.floor(anchor), offsets.length);
   const frac = anchor - Math.floor(anchor);
@@ -192,9 +233,10 @@ function pixelAtLine(offsets: number[], anchor: number): number {
  * Why a mirror: a <textarea> exposes no per-line geometry, and a wrapped <pre>'s
  * lines don't map to `lineHeight`. We replicate the element's content width,
  * font metrics, and wrap rules off-screen and read each line's real `offsetTop`.
- * Called once per mode switch, so a single layout pass is fine.
+ * Called once per mode switch, so a single layout pass is fine. Split-mode
+ * sync calls it per scroll but caches the result per (text, width).
  */
-function measureLineOffsets(reference: HTMLElement, text: string): number[] {
+export function measureLineOffsets(reference: HTMLElement, text: string): number[] {
   const cs = getComputedStyle(reference);
   const padL = parseFloat(cs.paddingLeft) || 0;
   const padR = parseFloat(cs.paddingRight) || 0;

--- a/src/lib/utils/split-sync.ts
+++ b/src/lib/utils/split-sync.ts
@@ -1,0 +1,124 @@
+import {
+  fractionalLineAtOffset,
+  measureLineOffsets,
+  pixelAtLine,
+  readBlockLineIn,
+  scrollBlocksToLineIn,
+} from "./scroll-sync";
+
+/**
+ * Two-way scroll sync between the split-mode editor and its live preview (#74).
+ *
+ * Both panes speak "fractional source line": the editor maps its scrollTop
+ * through the wrap-aware line offsets, the preview through the renderer's
+ * `data-source-line` stamps. Whichever pane the user scrolls drives the other.
+ *
+ * The one thing that goes wrong with two-way sync is the echo: driving pane B
+ * fires B's own scroll event, which would drive A back, which fires A's scroll
+ * event… so after driving a pane its scroll events are ignored for a short
+ * window. A user scroll on that pane inside the window is dropped, which is
+ * invisible; a feedback loop is not.
+ */
+
+export interface SyncPane {
+  /** Fractional source line at the top of this pane's viewport. */
+  readLine(): number;
+  /** Scroll this pane so `line` sits at the top of its viewport. */
+  scrollToLine(line: number): void;
+}
+
+export interface SplitSync {
+  onEditorScroll(): void;
+  onPreviewScroll(): void;
+  /** Force preview to follow the editor, e.g. right after the preview re-rendered. */
+  syncFromEditor(): void;
+  dispose(): void;
+}
+
+/** How long a pane's own scroll events are ignored after it was driven. */
+export const ECHO_WINDOW_MS = 150;
+
+export function createSplitSync(
+  editor: SyncPane,
+  preview: SyncPane,
+  now: () => number = () => performance.now()
+): SplitSync {
+  let muteEditorUntil = 0;
+  let mutePreviewUntil = 0;
+  let disposed = false;
+
+  function drive(from: SyncPane, to: SyncPane, target: "editor" | "preview") {
+    const line = from.readLine();
+    if (target === "preview") mutePreviewUntil = now() + ECHO_WINDOW_MS;
+    else muteEditorUntil = now() + ECHO_WINDOW_MS;
+    to.scrollToLine(line);
+  }
+
+  return {
+    onEditorScroll() {
+      if (disposed || now() < muteEditorUntil) return;
+      drive(editor, preview, "preview");
+    },
+    onPreviewScroll() {
+      if (disposed || now() < mutePreviewUntil) return;
+      drive(preview, editor, "editor");
+    },
+    syncFromEditor() {
+      if (disposed) return;
+      drive(editor, preview, "preview");
+    },
+    dispose() {
+      disposed = true;
+    },
+  };
+}
+
+/**
+ * Wire a textarea and a scrolling preview container together. Returns the
+ * controller; call `dispose()` when leaving split mode.
+ *
+ * Line offsets for the textarea come from an off-screen mirror (see
+ * `measureLineOffsets`) and are cached until the text or the pane width
+ * changes, so a scroll costs one binary search, not a layout pass.
+ */
+export function attachSplitSync(textarea: HTMLTextAreaElement, preview: HTMLElement): SplitSync {
+  let cachedText: string | null = null;
+  let cachedWidth = -1;
+  let cachedOffsets: number[] = [];
+  const offsets = (): number[] => {
+    const text = textarea.value;
+    const width = textarea.clientWidth;
+    if (text !== cachedText || width !== cachedWidth) {
+      cachedText = text;
+      cachedWidth = width;
+      cachedOffsets = measureLineOffsets(textarea, text);
+    }
+    return cachedOffsets;
+  };
+
+  const editorPane: SyncPane = {
+    readLine: () => fractionalLineAtOffset(offsets(), textarea.scrollTop),
+    scrollToLine: (line) => {
+      textarea.scrollTop = Math.round(pixelAtLine(offsets(), line));
+    },
+  };
+  const previewPane: SyncPane = {
+    readLine: () => readBlockLineIn(preview),
+    scrollToLine: (line) => scrollBlocksToLineIn(preview, line),
+  };
+
+  const sync = createSplitSync(editorPane, previewPane);
+  const onEditor = () => sync.onEditorScroll();
+  const onPreview = () => sync.onPreviewScroll();
+  textarea.addEventListener("scroll", onEditor, { passive: true });
+  preview.addEventListener("scroll", onPreview, { passive: true });
+
+  return {
+    ...sync,
+    dispose() {
+      textarea.removeEventListener("scroll", onEditor);
+      preview.removeEventListener("scroll", onPreview);
+      sync.dispose();
+    },
+  };
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -19,6 +19,7 @@
   import { settings, getContentMaxWidth } from "$lib/stores/settings";
   import { startFileWatcher, stopFileWatcher } from "$lib/tauri/watcher";
   import { restoreSession } from "$lib/tauri/session";
+  import { attachSplitSync, type SplitSync } from "$lib/utils/split-sync";
   import { themeMode, cycleTheme } from "$lib/stores/theme";
   import { getCurrentWindow } from "@tauri-apps/api/window";
   import { invoke } from "@tauri-apps/api/core";
@@ -192,8 +193,34 @@
       const result = renderFull(content, baseDir);
       allowAssets(result.assetPaths, activeTab.filePath);
       splitPreviewHtml = result.html;
+      // The re-render replaced the preview's blocks; put it back where the
+      // editor is so typing never leaves the two panes on different sections.
+      tick().then(() => splitSync?.syncFromEditor());
     }, 120);
     return () => clearTimeout(splitPreviewTimer);
+  });
+
+  // Split-mode scroll sync (#74): editor and preview follow each other. Keyed
+  // on the mode string, not the tab object, so a keystroke (which replaces the
+  // tab object) does not re-attach the listeners. Attached after tick so both
+  // panes exist; the first sync lands the preview where the editor already is.
+  let splitSync: SplitSync | null = null;
+  $effect(() => {
+    if (activeEditMode !== "split") return;
+    let gone = false;
+    tick().then(() => {
+      if (gone) return;
+      const ta = document.querySelector<HTMLTextAreaElement>("textarea.editor");
+      const preview = document.querySelector<HTMLElement>("main.split-preview");
+      if (!ta || !preview) return;
+      splitSync = attachSplitSync(ta, preview);
+      splitSync.syncFromEditor();
+    });
+    return () => {
+      gone = true;
+      splitSync?.dispose();
+      splitSync = null;
+    };
   });
 
   // Marp presentation (#44). `presenting` is a page-level view mode (like rawMode);

--- a/tests/unit/split-sync.test.ts
+++ b/tests/unit/split-sync.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it, vi } from "vitest";
+import { createSplitSync, ECHO_WINDOW_MS, type SyncPane } from "../../src/lib/utils/split-sync";
+import { fractionalLineAtOffset, lineAtOffset, pixelAtLine } from "../../src/lib/utils/scroll-sync";
+
+function pane(line = 0): SyncPane & { line: number; scrolls: number[] } {
+  const p = {
+    line,
+    scrolls: [] as number[],
+    readLine: () => p.line,
+    scrollToLine: vi.fn((l: number) => {
+      p.line = l;
+      p.scrolls.push(l);
+    }),
+  };
+  return p;
+}
+
+// #74: the split panes follow each other without fighting.
+describe("createSplitSync", () => {
+  it("drives the preview to the editor's line when the editor scrolls", () => {
+    let t = 0;
+    const editor = pane(12.5);
+    const preview = pane(0);
+    const sync = createSplitSync(editor, preview, () => t);
+
+    sync.onEditorScroll();
+
+    expect(preview.scrolls).toEqual([12.5]);
+    expect(editor.scrolls).toEqual([]);
+  });
+
+  it("drives the editor when the preview scrolls", () => {
+    let t = 0;
+    const editor = pane(0);
+    const preview = pane(40.25);
+    const sync = createSplitSync(editor, preview, () => t);
+
+    sync.onPreviewScroll();
+
+    expect(editor.scrolls).toEqual([40.25]);
+  });
+
+  it("ignores the echo scroll a driven pane fires back, so the panes never loop", () => {
+    let t = 0;
+    const editor = pane(7);
+    const preview = pane(0);
+    const sync = createSplitSync(editor, preview, () => t);
+
+    sync.onEditorScroll(); // drives preview → preview's own scroll event follows
+    t += 16;
+    sync.onPreviewScroll(); // the echo
+
+    expect(editor.scrolls).toEqual([]);
+    expect(preview.scrolls).toEqual([7]);
+  });
+
+  it("accepts a real scroll on the driven pane once the echo window has passed", () => {
+    let t = 0;
+    const editor = pane(7);
+    const preview = pane(0);
+    const sync = createSplitSync(editor, preview, () => t);
+
+    sync.onEditorScroll();
+    t += ECHO_WINDOW_MS + 1;
+    preview.line = 30;
+    sync.onPreviewScroll();
+
+    expect(editor.scrolls).toEqual([30]);
+  });
+
+  it("keeps following the editor through a continuous scroll", () => {
+    let t = 0;
+    const editor = pane(0);
+    const preview = pane(0);
+    const sync = createSplitSync(editor, preview, () => t);
+
+    for (const line of [1, 2, 3, 4]) {
+      editor.line = line;
+      sync.onEditorScroll();
+      t += 16;
+      sync.onPreviewScroll(); // echo each frame
+    }
+
+    expect(preview.scrolls).toEqual([1, 2, 3, 4]);
+    expect(editor.scrolls).toEqual([]);
+  });
+
+  it("syncFromEditor re-lands the preview after a re-render and mutes its echo", () => {
+    let t = 0;
+    const editor = pane(99);
+    const preview = pane(3);
+    const sync = createSplitSync(editor, preview, () => t);
+
+    sync.syncFromEditor();
+    sync.onPreviewScroll();
+
+    expect(preview.scrolls).toEqual([99]);
+    expect(editor.scrolls).toEqual([]);
+  });
+
+  it("does nothing after dispose", () => {
+    const editor = pane(5);
+    const preview = pane(0);
+    const sync = createSplitSync(editor, preview, () => 0);
+    sync.dispose();
+    sync.onEditorScroll();
+    sync.onPreviewScroll();
+    sync.syncFromEditor();
+    expect(preview.scrolls).toEqual([]);
+    expect(editor.scrolls).toEqual([]);
+  });
+});
+
+// The line ↔ pixel mapping both panes rely on. Offsets are the top of each
+// source line's first visual row; a wrapped line spans more than one row.
+describe("fractional line ↔ pixel mapping", () => {
+  const offsets = [0, 20, 40, 100, 120]; // line 2 wraps across 3 rows (40→100)
+
+  it("finds the line at a pixel by binary search", () => {
+    expect(lineAtOffset(offsets, 0)).toBe(0);
+    expect(lineAtOffset(offsets, 39)).toBe(1);
+    expect(lineAtOffset(offsets, 40)).toBe(2);
+    expect(lineAtOffset(offsets, 99)).toBe(2);
+    expect(lineAtOffset(offsets, 500)).toBe(4);
+  });
+
+  it("reports how far into a wrapped line the viewport is", () => {
+    expect(fractionalLineAtOffset(offsets, 70)).toBeCloseTo(2.5);
+    expect(fractionalLineAtOffset(offsets, 40)).toBe(2);
+  });
+
+  it("round-trips pixel → line → pixel", () => {
+    for (const y of [0, 10, 40, 70, 99, 110]) {
+      expect(pixelAtLine(offsets, fractionalLineAtOffset(offsets, y))).toBeCloseTo(y);
+    }
+  });
+
+  it("is safe on empty input and out-of-range lines", () => {
+    expect(fractionalLineAtOffset([], 50)).toBe(0);
+    expect(pixelAtLine([], 3)).toBe(0);
+    expect(pixelAtLine(offsets, 400)).toBe(120);
+    expect(pixelAtLine(offsets, -5)).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #74.

## What changes

In split mode the editor and the live preview now follow each other. Whichever pane you scroll drives the other, and after the preview re-renders while you type it is put back on the editor's line, so the two panes never drift onto different sections.

Both panes speak the same unit, a fractional source line, which is the anchor the View/Split/Edit switcher already uses. The editor maps its scroll position through the existing wrap-aware line offsets, cached until the text or the pane width changes. The preview maps through the `data-source-line` stamps the renderer already emits, read relative to its own scroll container rather than the window.

## The one thing that goes wrong with two-way sync

Driving pane B fires B's own scroll event, which would drive A back, and so on forever. After a pane is driven, its scroll events are ignored for 150 ms. A user scroll on that pane inside that window is dropped, which nobody can see; a feedback loop is very visible. The controller is a pure function over two pane adapters, so that guard is unit-tested with a fake clock rather than hoped for.

## Evidence

- 11 new tests: 7 on the controller (each direction, echo ignored, a real scroll after the window is accepted, continuous scroll, re-render re-land, dispose) and 4 on the line-to-pixel mapping (binary search, wrapped-line fraction, round trip, edge cases). Suite 88/88, types clean.
- Verified in a Chromium harness of the dev build on a 966-line, 373-block document, measured against the editor's line-number gutter rather than by eye. Editor-driven, the preview lands within 0.1 to 0.4 source lines at four positions. Preview-driven, the editor lands within about 1.1 lines, which is the renderer's block granularity (a list or table is stamped with its first line). Both panes settle with no oscillation. Appending text while scrolled to the middle leaves both panes where they were.

## Known limits

- Granularity is one top-level block, so a position deep inside a long list maps to the list's first line.
- Editor-driven sync anchors on the editor's top visible line, not the caret. Caret-following is a possible follow-up if users ask for it.
- Line offsets are re-measured after each edit on the next scroll; that is one layout pass over the document's lines, fine at a thousand lines, worth revisiting only if very large files lag.
