### PR TITLE
feat: live reload for every open tab, not just the active one

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -86,7 +86,8 @@ pub fn run() {
             commands::list_folder_md_files,
             commands::quit_app,
             commands::show_ai_context_menu,
-            watcher::start_watching,
+            watcher::watch_file,
+            watcher::unwatch_file,
             watcher::stop_watching,
             get_opened_files,
         ])

--- a/src-tauri/src/watcher.rs
+++ b/src-tauri/src/watcher.rs
@@ -1,87 +1,233 @@
-use notify_debouncer_mini::{new_debouncer, DebouncedEventKind};
-use std::path::PathBuf;
-use std::sync::Mutex;
+use notify_debouncer_mini::{new_debouncer, DebouncedEventKind, Debouncer};
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tauri::{AppHandle, Emitter, Manager};
 
+/// Which files are watched, and how many of them share each parent directory.
+///
+/// Pure bookkeeping, kept apart from `notify` so the reference-count rules are
+/// unit-testable: a directory starts being watched when its first file is
+/// added and stops when its last file is removed (#97).
+#[derive(Default)]
+pub struct WatchSet {
+    files: HashSet<PathBuf>,
+    dirs: HashMap<PathBuf, usize>,
+}
+
+impl WatchSet {
+    /// Add a file. Returns the parent directory if it must now start being
+    /// watched (this is its first file). Adding a file twice is a no-op.
+    pub fn add(&mut self, file: PathBuf) -> Option<PathBuf> {
+        let dir = file.parent()?.to_path_buf();
+        if !self.files.insert(file) {
+            return None;
+        }
+        let count = self.dirs.entry(dir.clone()).or_insert(0);
+        *count += 1;
+        (*count == 1).then_some(dir)
+    }
+
+    /// Remove a file. Returns the parent directory if it can now stop being
+    /// watched (this was its last file). Removing an unknown file is a no-op.
+    pub fn remove(&mut self, file: &Path) -> Option<PathBuf> {
+        if !self.files.remove(file) {
+            return None;
+        }
+        let dir = file.parent()?.to_path_buf();
+        match self.dirs.get_mut(&dir) {
+            Some(count) if *count > 1 => {
+                *count -= 1;
+                None
+            }
+            Some(_) => {
+                self.dirs.remove(&dir);
+                Some(dir)
+            }
+            None => None,
+        }
+    }
+
+    /// The stored path for `file`, if it is watched. The stored value is what
+    /// the frontend handed us, so emitting it back round-trips exactly.
+    pub fn watched(&self, file: &Path) -> Option<&PathBuf> {
+        self.files.get(file)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.files.is_empty()
+    }
+
+    pub fn clear(&mut self) {
+        self.files.clear();
+        self.dirs.clear();
+    }
+}
+
+type FsDebouncer = Debouncer<notify::RecommendedWatcher>;
+
+/// One debouncer for the whole app, created on the first watched file and
+/// dropped when the last one goes, watching each parent directory once no
+/// matter how many open tabs live in it. Watching the directory rather than
+/// the file survives atomic saves (write temp + rename), which is how most
+/// editors save.
 pub struct WatcherState {
-    watcher: Mutex<Option<notify_debouncer_mini::Debouncer<notify::RecommendedWatcher>>>,
-    watched_path: Mutex<Option<String>>,
+    debouncer: Mutex<Option<FsDebouncer>>,
+    set: Arc<Mutex<WatchSet>>,
 }
 
 impl Default for WatcherState {
     fn default() -> Self {
         Self {
-            watcher: Mutex::new(None),
-            watched_path: Mutex::new(None),
+            debouncer: Mutex::new(None),
+            set: Arc::new(Mutex::new(WatchSet::default())),
         }
     }
 }
 
-#[tauri::command]
-pub fn start_watching(app: AppHandle, path: String) -> Result<(), String> {
-    let state = app.state::<WatcherState>();
-    let mut watcher_lock = state.watcher.lock().map_err(|e| e.to_string())?;
-    let mut path_lock = state.watched_path.lock().map_err(|e| e.to_string())?;
-
-    // Stop existing watcher
-    *watcher_lock = None;
-
-    let watch_path = PathBuf::from(&path);
-    let target_file = watch_path.clone();
-
-    // Watch the parent directory to survive atomic saves (delete + rename)
-    let watch_dir = watch_path
-        .parent()
-        .ok_or_else(|| "Cannot determine parent directory".to_string())?
-        .to_path_buf();
-
+fn make_debouncer(app: &AppHandle, set: Arc<Mutex<WatchSet>>) -> Result<FsDebouncer, String> {
     let app_handle = app.clone();
-
-    let mut debouncer = new_debouncer(
+    new_debouncer(
         Duration::from_millis(500),
-        move |res: Result<Vec<notify_debouncer_mini::DebouncedEvent>, notify::Error>| {
-            match res {
-                Ok(events) => {
-                    for event in events {
-                        if event.kind == DebouncedEventKind::Any {
-                            // Only emit if the changed file matches our target
-                            if event.path == target_file {
-                                let _ = app_handle.emit(
-                                    "file-changed",
-                                    serde_json::json!({
-                                        "path": event.path.to_string_lossy()
-                                    }),
-                                );
-                            }
-                        }
+        move |res: Result<Vec<notify_debouncer_mini::DebouncedEvent>, notify::Error>| match res {
+            Ok(events) => {
+                for event in events {
+                    if event.kind != DebouncedEventKind::Any {
+                        continue;
+                    }
+                    // Only files an open tab asked for; everything else in the
+                    // directory is noise.
+                    let hit = set
+                        .lock()
+                        .ok()
+                        .and_then(|s| s.watched(&event.path).cloned());
+                    if let Some(path) = hit {
+                        let _ = app_handle.emit(
+                            "file-changed",
+                            serde_json::json!({ "path": path.to_string_lossy() }),
+                        );
                     }
                 }
-                Err(e) => {
-                    eprintln!("Watch error: {:?}", e);
-                }
             }
+            Err(e) => eprintln!("Watch error: {:?}", e),
         },
     )
-    .map_err(|e| format!("Failed to create watcher: {}", e))?;
+    .map_err(|e| format!("Failed to create watcher: {}", e))
+}
 
-    debouncer
-        .watcher()
-        .watch(&watch_dir, notify::RecursiveMode::NonRecursive)
-        .map_err(|e| format!("Failed to watch directory: {}", e))?;
-
-    *watcher_lock = Some(debouncer);
-    *path_lock = Some(path);
-
+/// Start delivering `file-changed` events for `path`. Safe to call for a file
+/// that is already watched.
+#[tauri::command]
+pub fn watch_file(app: AppHandle, path: String) -> Result<(), String> {
+    let state = app.state::<WatcherState>();
+    let mut debouncer = state.debouncer.lock().map_err(|e| e.to_string())?;
+    let file = PathBuf::from(&path);
+    let new_dir = state
+        .set
+        .lock()
+        .map_err(|e| e.to_string())?
+        .add(file.clone());
+    if let Some(dir) = new_dir {
+        if debouncer.is_none() {
+            *debouncer = Some(make_debouncer(&app, Arc::clone(&state.set))?);
+        }
+        let result = debouncer
+            .as_mut()
+            .expect("debouncer was just created")
+            .watcher()
+            .watch(&dir, notify::RecursiveMode::NonRecursive)
+            .map_err(|e| format!("Failed to watch directory: {}", e));
+        if result.is_err() {
+            // Roll the bookkeeping back so a retry starts clean.
+            if let Ok(mut set) = state.set.lock() {
+                set.remove(&file);
+            }
+            result?;
+        }
+    }
     Ok(())
 }
 
+/// Stop delivering events for `path`; the directory watch goes when its last
+/// file does, and the debouncer (a thread plus OS handles) goes with the last
+/// directory.
+#[tauri::command]
+pub fn unwatch_file(app: AppHandle, path: String) -> Result<(), String> {
+    let state = app.state::<WatcherState>();
+    let mut debouncer = state.debouncer.lock().map_err(|e| e.to_string())?;
+    let (gone_dir, empty) = {
+        let mut set = state.set.lock().map_err(|e| e.to_string())?;
+        let gone = set.remove(Path::new(&path));
+        (gone, set.is_empty())
+    };
+    if let (Some(dir), Some(d)) = (gone_dir, debouncer.as_mut()) {
+        let _ = d.watcher().unwatch(&dir);
+    }
+    if empty {
+        *debouncer = None;
+    }
+    Ok(())
+}
+
+/// Drop every watch. Used at shutdown of the frontend listener.
 #[tauri::command]
 pub fn stop_watching(app: AppHandle) -> Result<(), String> {
     let state = app.state::<WatcherState>();
-    let mut watcher_lock = state.watcher.lock().map_err(|e| e.to_string())?;
-    let mut path_lock = state.watched_path.lock().map_err(|e| e.to_string())?;
-    *watcher_lock = None;
-    *path_lock = None;
+    let mut debouncer = state.debouncer.lock().map_err(|e| e.to_string())?;
+    state.set.lock().map_err(|e| e.to_string())?.clear();
+    *debouncer = None;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::WatchSet;
+    use std::path::{Path, PathBuf};
+
+    fn p(s: &str) -> PathBuf {
+        PathBuf::from(s)
+    }
+
+    #[test]
+    fn first_file_in_a_directory_starts_the_watch_and_the_last_stops_it() {
+        let mut set = WatchSet::default();
+        assert_eq!(set.add(p("/docs/a.md")), Some(p("/docs")));
+        assert_eq!(set.add(p("/docs/b.md")), None, "second file in the same dir reuses the watch");
+        assert_eq!(set.remove(Path::new("/docs/a.md")), None, "one file still needs the dir");
+        assert_eq!(set.remove(Path::new("/docs/b.md")), Some(p("/docs")));
+        assert!(set.is_empty());
+    }
+
+    #[test]
+    fn directories_are_counted_independently() {
+        let mut set = WatchSet::default();
+        assert_eq!(set.add(p("/docs/a.md")), Some(p("/docs")));
+        assert_eq!(set.add(p("/notes/n.md")), Some(p("/notes")));
+        assert_eq!(set.remove(Path::new("/docs/a.md")), Some(p("/docs")));
+        assert!(!set.is_empty());
+        assert!(set.watched(Path::new("/notes/n.md")).is_some());
+    }
+
+    #[test]
+    fn adding_twice_and_removing_the_unknown_are_no_ops() {
+        let mut set = WatchSet::default();
+        assert_eq!(set.add(p("/docs/a.md")), Some(p("/docs")));
+        assert_eq!(set.add(p("/docs/a.md")), None);
+        // Still exactly one reference: removing it releases the directory.
+        assert_eq!(set.remove(Path::new("/docs/a.md")), Some(p("/docs")));
+        assert_eq!(set.remove(Path::new("/docs/never.md")), None);
+        assert_eq!(set.remove(Path::new("/docs/a.md")), None);
+    }
+
+    #[test]
+    fn only_watched_files_match_and_the_stored_path_is_returned() {
+        let mut set = WatchSet::default();
+        set.add(p("/docs/a.md"));
+        assert_eq!(set.watched(Path::new("/docs/a.md")), Some(&p("/docs/a.md")));
+        assert_eq!(set.watched(Path::new("/docs/other.md")), None, "a sibling's change is noise");
+        set.clear();
+        assert!(set.is_empty());
+        assert_eq!(set.watched(Path::new("/docs/a.md")), None);
+    }
 }

--- a/src/lib/components/TabBar.svelte
+++ b/src/lib/components/TabBar.svelte
@@ -142,7 +142,7 @@
           class:drag-over={overIndex === idx && dragIndex !== idx && dragIndex >= 0}
         >
           <span class="tab-label">
-            {#if tab.dirty}<span class="tab-dirty" title="Unsaved changes">•</span>{/if}{tab.fileName}
+            {#if tab.diskChanged}<span class="tab-disk" title="Changed on disk while you were editing">⟳</span>{:else if tab.dirty}<span class="tab-dirty" title="Unsaved changes">•</span>{/if}{tab.fileName}
           </span>
           <!-- svelte-ignore a11y_no_static_element_interactions -->
           <span
@@ -279,6 +279,12 @@
     text-overflow: ellipsis;
     flex: 1;
     text-align: left;
+  }
+
+  .tab-disk {
+    color: #d97706;
+    margin-right: 4px;
+    font-size: 0.9em;
   }
 
   .tab-dirty {

--- a/src/lib/stores/tabs.ts
+++ b/src/lib/stores/tabs.ts
@@ -13,6 +13,12 @@ export interface Tab {
   editContent: string;
   dirty: boolean;
   lastSavedAt: number;
+  /**
+   * The file changed on disk while this tab had unsaved edits (#97). The edits
+   * are kept; this flag marks the tab and makes Save ask before overwriting.
+   * Cleared by a save, or once the tab is no longer dirty.
+   */
+  diskChanged: boolean;
 }
 
 export const HOME_TAB_ID = "__home__";
@@ -123,6 +129,7 @@ function createTabStore() {
       editContent: content,
       dirty: false,
       lastSavedAt: 0,
+      diskChanged: false,
     };
 
     tabs.update((ts) => [...ts, newTab]);
@@ -186,9 +193,14 @@ function createTabStore() {
         // Preserve in-progress edits when content updates from external sources (file watcher)
         if (t.isEditing) {
           next.dirty = t.editContent !== content;
+          // Remember that the disk moved under unsaved edits, so the tab can
+          // show it and Save can ask first (#97). Not raised when the disk
+          // now matches what the user typed — there is nothing to lose then.
+          next.diskChanged = next.dirty && (t.diskChanged || content !== t.content);
         } else {
           next.editContent = content;
           next.dirty = false;
+          next.diskChanged = false;
         }
         return next;
       })
@@ -236,7 +248,7 @@ function createTabStore() {
     tabs.update((ts) =>
       ts.map((t) => {
         if (t.id !== id) return t;
-        return { ...t, content: t.editContent, dirty: false, lastSavedAt: Date.now() };
+        return { ...t, content: t.editContent, dirty: false, diskChanged: false, lastSavedAt: Date.now() };
       })
     );
   }

--- a/src/lib/tauri/files.ts
+++ b/src/lib/tauri/files.ts
@@ -42,6 +42,7 @@ export async function openFile(path: string): Promise<void> {
     await allowAssets(result.assetPaths, absolutePath);
 
     const tabId = tabStore.addTab(absolutePath, fileName, content, result.html, result.frontmatter, result.wordCount);
+    watchFile(absolutePath);
 
     // An empty file has nothing to read — drop straight into the editor so the
     // user can start writing, instead of staring at a blank viewer (#52).
@@ -113,6 +114,7 @@ export async function saveAsNewDocument(tabId: string, content: string): Promise
   const fileName = basename(chosen);
   await saveFile(chosen, content);
   tabStore.rebindPath(tabId, chosen, fileName);
+  watchFile(chosen);
   addRecentFile(chosen, fileName);
   getCurrentWindow().setTitle(`${fileName} — MDHero`).catch(() => {});
   return chosen;
@@ -140,7 +142,14 @@ export async function openFileDialog(): Promise<void> {
   }
 }
 
-export async function reloadCurrentFile(path: string): Promise<void> {
+/**
+ * Re-read `path` from disk after the watcher saw it change (#97). The content
+ * goes to the tab that owns the file — every open tab, not just the active one
+ * — and the on-screen document is repainted only when that tab is the active
+ * one. Before that guard a background file's reload was painted over whatever
+ * the user was reading, the root of the #68 / #91 class of bugs.
+ */
+export async function reloadFile(path: string): Promise<void> {
   try {
     const absolutePath = await resolvePath(path);
     const content = await readMarkdownFile(absolutePath);
@@ -151,6 +160,8 @@ export async function reloadCurrentFile(path: string): Promise<void> {
     await allowAssets(result.assetPaths, absolutePath);
 
     tabStore.updateTabContent(absolutePath, content, result.html, result.frontmatter, result.wordCount);
+
+    if (tabStore.getActiveTab()?.filePath !== absolutePath) return;
 
     document.set({
       filePath: absolutePath,
@@ -165,6 +176,26 @@ export async function reloadCurrentFile(path: string): Promise<void> {
   } catch (err) {
     console.error("Failed to reload file:", err);
   }
+}
+
+/** A path the file watcher can do something with: on disk, not a tab sentinel. */
+export function isWatchablePath(path: string): boolean {
+  return !!path
+    && !path.startsWith("paste://")
+    && !path.startsWith("new://")
+    && !path.startsWith("url://");
+}
+
+/** Ask the backend to deliver `file-changed` events for this file (#97). */
+export function watchFile(path: string): void {
+  if (!isWatchablePath(path)) return;
+  invoke("watch_file", { path }).catch(() => {});
+}
+
+/** Stop events for this file; the directory watch is released with its last file. */
+export function unwatchFile(path: string): void {
+  if (!isWatchablePath(path)) return;
+  invoke("unwatch_file", { path }).catch(() => {});
 }
 
 export function getBaseDir(path: string): string {

--- a/src/lib/tauri/watcher.ts
+++ b/src/lib/tauri/watcher.ts
@@ -1,51 +1,61 @@
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { invoke } from "@tauri-apps/api/core";
-import { reloadCurrentFile } from "./files";
+import { reloadFile } from "./files";
 import { tabStore } from "../stores/tabs";
 
+/**
+ * Frontend half of live reload (#97). One listener for the whole session; the
+ * backend watches every open tab's file and says which one changed, and the
+ * reload goes to that file's tab. Which files are watched is decided where
+ * tabs are opened, closed and re-pathed (`watchFile` / `unwatchFile` in
+ * files.ts), not here.
+ */
+
 let unlisten: UnlistenFn | null = null;
-let reloadTimeout: ReturnType<typeof setTimeout> | null = null;
+let starting: Promise<void> | null = null;
+// Per-path debounce: editors fire several events per save, and two files
+// changing together must not cancel each other's reload.
+const pending = new Map<string, ReturnType<typeof setTimeout>>();
 
 const OWN_SAVE_SUPPRESSION_MS = 1500;
+const COALESCE_MS = 100;
 
-export async function startFileWatcher(filePath: string): Promise<void> {
-  if (unlisten) {
-    unlisten();
-  }
-
-  unlisten = await listen<{ path: string }>("file-changed", () => {
-    // Debounce on frontend too — editors may trigger multiple events
-    if (reloadTimeout) clearTimeout(reloadTimeout);
-    reloadTimeout = setTimeout(() => {
-      // Skip reload if this file-changed event was triggered by our own save
-      const lastSavedAt = tabStore.getLastSavedAt(filePath);
-      if (lastSavedAt && Date.now() - lastSavedAt < OWN_SAVE_SUPPRESSION_MS) {
-        return;
-      }
-      reloadCurrentFile(filePath);
-    }, 100);
+export function initFileWatcher(): Promise<void> {
+  if (unlisten) return Promise.resolve();
+  if (starting) return starting;
+  starting = listen<{ path: string }>("file-changed", (event) => {
+    const path = event.payload?.path;
+    if (!path) return;
+    const prev = pending.get(path);
+    if (prev) clearTimeout(prev);
+    pending.set(
+      path,
+      setTimeout(() => {
+        pending.delete(path);
+        // Our own save just wrote this file; the tab already has that content.
+        const lastSavedAt = tabStore.getLastSavedAt(path);
+        if (lastSavedAt && Date.now() - lastSavedAt < OWN_SAVE_SUPPRESSION_MS) return;
+        void reloadFile(path);
+      }, COALESCE_MS)
+    );
+  }).then((un) => {
+    unlisten = un;
+    starting = null;
   });
-
-  // The Rust watcher tracks only one file. Re-start it whenever the active
-  // tab changes so returning to a previously opened tab watches its file again.
-  invoke("start_watching", { path: filePath }).catch(() => {});
+  return starting;
 }
 
 /**
- * Tear the watcher down on both sides of the IPC boundary.
- *
- * Dropping only the JS listener would leave the Rust debouncer watching the
- * directory of a file nobody has open any more — it keeps a thread and an OS
- * watch handle alive for the rest of the session.
+ * Tear the watcher down on both sides of the IPC boundary. Dropping only the
+ * JS listener would leave the Rust debouncer and its OS watch handles alive.
  */
 export function stopFileWatcher(): void {
-  if (reloadTimeout) {
-    clearTimeout(reloadTimeout);
-    reloadTimeout = null;
-  }
+  for (const t of pending.values()) clearTimeout(t);
+  pending.clear();
   if (unlisten) {
     unlisten();
     unlisten = null;
   }
+  starting = null;
   invoke("stop_watching").catch(() => {});
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -13,11 +13,12 @@
     pathExists,
     saveAsNewDocument,
     saveFile,
+    unwatchFile,
   } from "$lib/tauri/files";
   import { showToast } from "$lib/stores/toast";
   import { basename } from "$lib/utils/path";
   import { settings, getContentMaxWidth } from "$lib/stores/settings";
-  import { startFileWatcher, stopFileWatcher } from "$lib/tauri/watcher";
+  import { initFileWatcher, stopFileWatcher } from "$lib/tauri/watcher";
   import { restoreSession } from "$lib/tauri/session";
   import { attachSplitSync, type SplitSync } from "$lib/utils/split-sync";
   import { themeMode, cycleTheme } from "$lib/stores/theme";
@@ -53,7 +54,6 @@
   import { saveProgress, getProgress } from "$lib/stores/readingProgress";
 
   let rendererReady = $state(false);
-  let lastWatchedPath: string | null = null;
   let searchVisible = $state(false);
   let pasteVisible = $state(false);
   let pasteDefaultMode = $state<"paste" | "url">("paste");
@@ -314,6 +314,17 @@
         targetPath = saved;
         targetName = basename(saved);
       } else {
+        if (tab.diskChanged) {
+          // The file changed on disk while these edits were unsaved (#97).
+          // Same convention as the close dialog: the default button is the
+          // safe one, so a reflexive Return keeps editing.
+          const { ask } = await import("@tauri-apps/plugin-dialog");
+          const keepEditing = await ask(
+            `${tab.fileName} changed on disk while you were editing. Saving will overwrite that version.`,
+            { title: "File changed on disk", kind: "warning", okLabel: "Keep Editing", cancelLabel: "Overwrite" }
+          );
+          if (keepEditing) return;
+        }
         await saveFile(tab.filePath, tab.editContent);
       }
       const baseDir = getBaseDir(targetPath);
@@ -476,6 +487,7 @@
       saveProgressNow();
     }
     tabStore.closeTab(id);
+    unwatchFile(t.filePath);
     return true;
   }
 
@@ -655,6 +667,10 @@
     window.addEventListener("beforeunload", saveProgressNow);
     document.addEventListener("visibilitychange", handleVisibilityChange);
 
+    // One file-changed listener for the session (#97); which files are watched
+    // follows the tabs (open / close / save-as), not the active document.
+    void initFileWatcher();
+
     void (async () => {
       // Bring back last run's tabs first (#72), so a file opened via "Open
       // With" or the CLI below lands on top of them as the active tab.
@@ -689,6 +705,7 @@
     })();
 
     return () => {
+      stopFileWatcher();
       window.removeEventListener("keydown", handleKeydown);
       window.removeEventListener("keyup", handleKeyup);
       window.removeEventListener("blur", stopScroll);
@@ -1103,35 +1120,6 @@
     });
   });
 
-  // Start/stop the file watcher as the active document changes.
-  //
-  // The stop half matters: closing the last tab leaves docStore.filePath null,
-  // and without an explicit teardown the watcher for the file just closed kept
-  // running. An external edit to it then fired reloadCurrentFile, which calls
-  // docStore.set — so a document the user had closed reappeared on top of the
-  // home screen. `url://` joins the sentinels here too: it is not a filesystem
-  // path, so start_watching could never do anything useful with it.
-  $effect(() => {
-    const path = $docStore.filePath;
-    const watchable =
-      !!path
-      && !path.startsWith("paste://")
-      && !path.startsWith("new://")
-      && !path.startsWith("url://");
-
-    if (!watchable) {
-      if (lastWatchedPath !== null) {
-        lastWatchedPath = null;
-        stopFileWatcher();
-      }
-      return;
-    }
-
-    if (path !== lastWatchedPath) {
-      lastWatchedPath = path;
-      startFileWatcher(path);
-    }
-  });
 </script>
 
 <div class="min-h-screen transition-colors page-root">

--- a/tests/unit/reload-file.test.ts
+++ b/tests/unit/reload-file.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const invoke = vi.fn();
+const documentSet = vi.fn();
+const updateTabContent = vi.fn();
+const addTab = vi.fn(() => "tab-1");
+const rebindPath = vi.fn();
+let activeTab: { filePath: string } | null = null;
+
+// Node has no DOM for DOMPurify; the renderer is not under test here.
+vi.mock("dompurify", () => ({ default: { sanitize: (html: string) => html } }));
+vi.mock("@tauri-apps/api/core", () => ({ invoke }));
+vi.mock("@tauri-apps/plugin-dialog", () => ({ open: vi.fn(), save: vi.fn(async () => "/docs/chosen.md") }));
+vi.mock("@tauri-apps/api/window", () => ({ getCurrentWindow: () => ({ setTitle: async () => {} }) }));
+vi.mock("../../src/lib/stores/pinned", () => ({ pinnedFolders: { subscribe: (run: (v: string[]) => void) => (run([]), () => {}) } }));
+vi.mock("../../src/lib/stores/recents", () => ({ addRecentFile: vi.fn() }));
+vi.mock("../../src/lib/stores/document", () => ({ document: { set: documentSet } }));
+vi.mock("../../src/lib/stores/tabs", () => ({
+  tabStore: { updateTabContent, addTab, rebindPath, setEditing: vi.fn(), getActiveTab: () => activeTab },
+}));
+
+const { reloadFile, openFile, saveAsNewDocument, watchFile, unwatchFile } = await import("../../src/lib/tauri/files");
+
+const calls = (cmd: string) => invoke.mock.calls.filter((c) => c[0] === cmd).map((c) => c[1]);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  activeTab = null;
+  invoke.mockImplementation(async (cmd: string, args: any) => {
+    if (cmd === "resolve_path") return args.path;
+    if (cmd === "read_markdown_file") return "# from disk";
+    if (cmd === "path_exists") return true;
+    return undefined;
+  });
+});
+
+// #97: a reload goes to the tab that owns the file; the screen only repaints
+// when that tab is the one being looked at.
+describe("reloadFile routing", () => {
+  it("updates the owning tab but leaves the screen alone when another tab is active", async () => {
+    activeTab = { filePath: "/docs/b.md" };
+    await reloadFile("/docs/a.md");
+    expect(updateTabContent).toHaveBeenCalledWith("/docs/a.md", "# from disk", expect.any(String), null, expect.any(Number));
+    expect(documentSet).not.toHaveBeenCalled();
+  });
+
+  it("repaints the screen when the changed file is the active tab", async () => {
+    activeTab = { filePath: "/docs/a.md" };
+    await reloadFile("/docs/a.md");
+    expect(updateTabContent).toHaveBeenCalledTimes(1);
+    expect(documentSet).toHaveBeenCalledTimes(1);
+    expect(documentSet.mock.calls[0][0]).toMatchObject({ filePath: "/docs/a.md", content: "# from disk" });
+  });
+
+  it("leaves the home screen alone when no tab is active", async () => {
+    activeTab = null;
+    await reloadFile("/docs/a.md");
+    expect(updateTabContent).toHaveBeenCalledTimes(1);
+    expect(documentSet).not.toHaveBeenCalled();
+  });
+});
+
+describe("watch lifecycle", () => {
+  it("starts watching a file when it is opened", async () => {
+    await openFile("/docs/a.md");
+    expect(calls("watch_file")).toEqual([{ path: "/docs/a.md" }]);
+  });
+
+  it("starts watching the chosen path when a new document is saved for the first time", async () => {
+    const chosen = await saveAsNewDocument("tab-1", "# draft");
+    expect(chosen).toBe("/docs/chosen.md");
+    expect(calls("watch_file")).toEqual([{ path: "/docs/chosen.md" }]);
+  });
+
+  it("never asks the backend to watch a tab sentinel", () => {
+    for (const p of ["paste://1", "new://2", "url://https://x/y.md", ""]) {
+      watchFile(p);
+      unwatchFile(p);
+    }
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it("unwatches by the same path it watched", () => {
+    watchFile("/docs/a.md");
+    unwatchFile("/docs/a.md");
+    expect(calls("watch_file")).toEqual([{ path: "/docs/a.md" }]);
+    expect(calls("unwatch_file")).toEqual([{ path: "/docs/a.md" }]);
+  });
+});

--- a/tests/unit/tabs-disk-changed.test.ts
+++ b/tests/unit/tabs-disk-changed.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest";
+
+async function freshStore() {
+  vi.resetModules();
+  const map = new Map<string, string>();
+  (globalThis as any).localStorage = { getItem: (k: string) => map.get(k) ?? null, setItem: (k: string, v: string) => void map.set(k, v) };
+  (globalThis as any).window = { scrollY: 0 };
+  return (await import("../../src/lib/stores/tabs")).tabStore;
+}
+
+// #97: when a file changes on disk under a tab with unsaved edits, the edits
+// are kept and the tab is marked so Save can ask before overwriting.
+describe("diskChanged", () => {
+  it("is raised when the disk moves under unsaved edits, and the edits survive", async () => {
+    const store = await freshStore();
+    const id = store.addTab("/docs/a.md", "a.md", "v1", "");
+    store.setEditing(id, true);
+    store.updateEditContent(id, "v1 plus my typing");
+
+    store.updateTabContent("/docs/a.md", "v2 from someone else", "");
+
+    const tab = store.getActiveTab()!;
+    expect(tab.editContent).toBe("v1 plus my typing");
+    expect(tab.content).toBe("v2 from someone else");
+    expect(tab.dirty).toBe(true);
+    expect(tab.diskChanged).toBe(true);
+  });
+
+  it("is not raised when the tab is not editing, or when the disk now matches the edits", async () => {
+    const store = await freshStore();
+    const id = store.addTab("/docs/a.md", "a.md", "v1", "");
+    store.updateTabContent("/docs/a.md", "v2", "");
+    expect(store.getActiveTab()!.diskChanged).toBe(false);
+
+    store.setEditing(id, true);
+    store.updateEditContent(id, "v3");
+    store.updateTabContent("/docs/a.md", "v3", ""); // someone saved exactly what I typed
+    expect(store.getActiveTab()!.dirty).toBe(false);
+    expect(store.getActiveTab()!.diskChanged).toBe(false);
+  });
+
+  it("clears on save", async () => {
+    const store = await freshStore();
+    const id = store.addTab("/docs/a.md", "a.md", "v1", "");
+    store.setEditing(id, true);
+    store.updateEditContent(id, "mine");
+    store.updateTabContent("/docs/a.md", "theirs", "");
+    expect(store.getActiveTab()!.diskChanged).toBe(true);
+
+    store.markSaved(id);
+    expect(store.getActiveTab()!.diskChanged).toBe(false);
+    expect(store.getActiveTab()!.dirty).toBe(false);
+  });
+
+  it("stays raised across a second disk change while still dirty", async () => {
+    const store = await freshStore();
+    const id = store.addTab("/docs/a.md", "a.md", "v1", "");
+    store.setEditing(id, true);
+    store.updateEditContent(id, "mine");
+    store.updateTabContent("/docs/a.md", "theirs 1", "");
+    store.updateTabContent("/docs/a.md", "theirs 2", "");
+    expect(store.getActiveTab()!.diskChanged).toBe(true);
+  });
+});

--- a/tests/unit/watcher.test.ts
+++ b/tests/unit/watcher.test.ts
@@ -1,64 +1,89 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const listen = vi.fn();
 const invoke = vi.fn();
-const reloadCurrentFile = vi.fn();
+const reloadFile = vi.fn();
+const getLastSavedAt = vi.fn((_path: string) => 0);
 
 vi.mock("@tauri-apps/api/event", () => ({ listen }));
 vi.mock("@tauri-apps/api/core", () => ({ invoke }));
-vi.mock("../../src/lib/tauri/files", () => ({ reloadCurrentFile }));
-vi.mock("../../src/lib/stores/tabs", () => ({
-  tabStore: { getLastSavedAt: vi.fn(() => 0) },
-}));
+vi.mock("../../src/lib/tauri/files", () => ({ reloadFile }));
+vi.mock("../../src/lib/stores/tabs", () => ({ tabStore: { getLastSavedAt } }));
 
-const { startFileWatcher, stopFileWatcher } = await import("../../src/lib/tauri/watcher");
+const { initFileWatcher, stopFileWatcher } = await import("../../src/lib/tauri/watcher");
 
-describe("file watcher", () => {
+// #97: one session-wide listener; the backend says which file changed and the
+// reload goes to that file, whichever tab owns it.
+describe("file watcher (all tabs)", () => {
+  let handler: ((e: { payload: { path: string } }) => void) | null = null;
+  const unlistenFn = vi.fn();
+
   beforeEach(() => {
-    // Order matters twice over. The mocks are configured first because
-    // stopFileWatcher now invokes "stop_watching" and awaits it — an
-    // unconfigured vi.fn() returns undefined, not a promise. Then the teardown
-    // runs, and clearAllMocks wipes its calls so they don't land in the
-    // per-test counts below (it clears calls only, implementations survive).
-    listen.mockResolvedValue(vi.fn());
+    vi.useFakeTimers();
+    // stopFileWatcher awaits invoke("stop_watching"); an unconfigured vi.fn()
+    // returns undefined, not a promise, so configure it before the teardown.
     invoke.mockResolvedValue(undefined);
     stopFileWatcher();
     vi.clearAllMocks();
+    getLastSavedAt.mockReturnValue(0);
+    invoke.mockResolvedValue(undefined);
+    listen.mockImplementation(async (_name: string, cb: typeof handler) => {
+      handler = cb;
+      return unlistenFn;
+    });
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it("registers exactly one listener no matter how often it is initialised", async () => {
+    await initFileWatcher();
+    await initFileWatcher();
+    await initFileWatcher();
+    expect(listen).toHaveBeenCalledTimes(1);
+    expect(listen.mock.calls[0][0]).toBe("file-changed");
   });
 
-  it("restarts the backend watcher when switching between file tabs", async () => {
-    await startFileWatcher("C:/docs/a.md");
-    await startFileWatcher("C:/docs/b.md");
-    await startFileWatcher("C:/docs/a.md");
-
-    expect(invoke).toHaveBeenNthCalledWith(1, "start_watching", { path: "C:/docs/a.md" });
-    expect(invoke).toHaveBeenNthCalledWith(2, "start_watching", { path: "C:/docs/b.md" });
-    expect(invoke).toHaveBeenNthCalledWith(3, "start_watching", { path: "C:/docs/a.md" });
-    expect(invoke).toHaveBeenCalledTimes(3);
-    expect(listen).toHaveBeenCalledTimes(3);
+  it("reloads the file named in the event, after coalescing a burst", async () => {
+    await initFileWatcher();
+    handler!({ payload: { path: "/docs/a.md" } });
+    handler!({ payload: { path: "/docs/a.md" } });
+    handler!({ payload: { path: "/docs/a.md" } });
+    vi.advanceTimersByTime(150);
+    expect(reloadFile).toHaveBeenCalledTimes(1);
+    expect(reloadFile).toHaveBeenCalledWith("/docs/a.md");
   });
 
-  // Closing the last tab used to leave the Rust watcher running: an external
-  // edit to the closed file then pushed it back into the document store, on top
-  // of the home screen.
-  it("stops the backend watcher, not just the event listener", async () => {
-    const firstUnlisten = vi.fn();
-    listen.mockResolvedValueOnce(firstUnlisten);
+  it("keeps two files' reloads independent — a background tab's change is not lost", async () => {
+    await initFileWatcher();
+    handler!({ payload: { path: "/docs/a.md" } });
+    handler!({ payload: { path: "/docs/b.md" } });
+    vi.advanceTimersByTime(150);
+    expect(reloadFile.mock.calls.map((c) => c[0]).sort()).toEqual(["/docs/a.md", "/docs/b.md"]);
+  });
 
-    await startFileWatcher("C:/docs/a.md");
+  it("skips the event caused by our own save of that file, and only that file", async () => {
+    await initFileWatcher();
+    getLastSavedAt.mockImplementation((p: string) => (p === "/docs/a.md" ? Date.now() : 0));
+    handler!({ payload: { path: "/docs/a.md" } });
+    handler!({ payload: { path: "/docs/b.md" } });
+    vi.advanceTimersByTime(150);
+    expect(reloadFile).toHaveBeenCalledTimes(1);
+    expect(reloadFile).toHaveBeenCalledWith("/docs/b.md");
+  });
+
+  it("ignores an event without a path", async () => {
+    await initFileWatcher();
+    handler!({ payload: {} as any });
+    vi.advanceTimersByTime(150);
+    expect(reloadFile).not.toHaveBeenCalled();
+  });
+
+  it("stops on both sides: unlistens, cancels pending reloads, tells the backend", async () => {
+    await initFileWatcher();
+    handler!({ payload: { path: "/docs/a.md" } });
     stopFileWatcher();
-
-    expect(firstUnlisten).toHaveBeenCalledOnce();
-    expect(invoke).toHaveBeenLastCalledWith("stop_watching");
-  });
-
-  it("unsubscribes the previous event listener when switching files", async () => {
-    const firstUnlisten = vi.fn();
-    listen.mockResolvedValueOnce(firstUnlisten).mockResolvedValueOnce(vi.fn());
-
-    await startFileWatcher("C:/docs/a.md");
-    await startFileWatcher("C:/docs/b.md");
-
-    expect(firstUnlisten).toHaveBeenCalledOnce();
+    vi.advanceTimersByTime(150);
+    expect(unlistenFn).toHaveBeenCalledTimes(1);
+    expect(reloadFile).not.toHaveBeenCalled();
+    expect(invoke).toHaveBeenCalledWith("stop_watching");
   });
 });


### PR DESCRIPTION
Closes #97.

## What changes

Live reload now covers every open tab, not just the active one. Edit a file in another editor while its tab sits in the background and the tab has the new content the moment you switch to it. The document on screen is only ever repainted for the tab you are looking at.

The old design was one watcher slot that followed the active tab, and a reload that wrote into the active view regardless of which tab owned the file. #68, the home-screen reappearance and the paste-tab clobber that #91 closed were all symptoms of that one design.

**Backend.** One `notify` debouncer for the whole app, created on the first watched file and dropped with the last. It watches each parent directory once, reference-counted, however many open tabs live there, and emits `file-changed` only for files an open tab asked for. The bookkeeping is a pure `WatchSet` with its own tests. Commands are now `watch_file`, `unwatch_file` and `stop_watching`; `start_watching` is gone.

**Frontend.** One `file-changed` listener for the session, debounced per path so two files changing together do not cancel each other, with own-save suppression per path. Watches follow the tabs: open and first save watch, close unwatches, session restore goes through open. The effect that re-targeted the watcher on every tab switch is gone.

`reloadFile` routes disk content to the owning tab and repaints the screen only when that tab is active. That guard alone removes the "wrong document appears" class of bug.

**The one product decision**, taken the way VS Code takes it: when a file changes on disk under a tab with unsaved edits, the edits are kept, the tab shows an orange ⟳ instead of the dirty dot, and Save asks before overwriting, with Keep Editing as the default button so a reflexive Return cannot destroy either side.

## Evidence

- Rust: 4 tests on the reference count (start on first file, stop on last, independent directories, double add and unknown remove are no-ops, only watched files match). Breaking the count turns one red. Suite 23/23.
- JS: 17 new tests across the listener (single registration, coalescing, independent paths, per-path own-save skip, event without path, teardown on both sides), reload routing and the watch lifecycle, and the disk-changed flag. Removing the routing guard turns two red. Suite 102/102, types clean.
- Smoked in the debug app with six restored tabs in one directory and b.md active: an external edit to a.md left b.md on screen untouched and was already in the a.md tab on switching to it; an external edit to b.md updated it live; typing in b.md and then editing it outside showed the ⟳ marker with the typing intact; ⌘S produced the changed-on-disk dialog.

## Notes

- The watcher key is the exact path string the frontend handed over, so the event round-trips without any path normalisation on the way back.
- Watching the directory rather than the file survives atomic saves (write temp, rename), which is how most editors save.
