### PR TITLE
fix(security): sanitize Mermaid output, add a CSP, scope the filesystem commands

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -22,9 +22,29 @@ pub fn quit_app(app: tauri::AppHandle) {
     app.exit(0);
 }
 
+/// Extensions the app is allowed to read from / write to on behalf of the
+/// web view. MDHero is a markdown app: a document, its links and its saves are
+/// text. Bounding the two filesystem commands to this set means that even if a
+/// script ever ran in the web view (see the Mermaid/CSP hardening), it cannot
+/// turn `read_markdown_file` / `write_markdown_file` into an arbitrary-file
+/// read/write primitive against `~/.ssh/id_rsa`, `authorized_keys` and the
+/// like. (Felipe Boralli disclosure, 2026-08-14.)
+const ALLOWED_TEXT_EXTENSIONS: &[&str] = &["md", "markdown", "mdown", "mkd", "mdx", "txt", "text"];
+
+fn has_allowed_extension(p: &Path) -> bool {
+    p.extension()
+        .and_then(|e| e.to_str())
+        .map(|e| ALLOWED_TEXT_EXTENSIONS.iter().any(|a| a.eq_ignore_ascii_case(e)))
+        .unwrap_or(false)
+}
+
 #[tauri::command]
 pub fn read_markdown_file(path: String) -> Result<String, String> {
     let p = Path::new(&path);
+
+    if !has_allowed_extension(p) {
+        return Err(format!("Refusing to read a non-text file: {}", path));
+    }
 
     if !p.exists() {
         return Err(format!("File not found: {}", path));
@@ -40,6 +60,10 @@ pub fn read_markdown_file(path: String) -> Result<String, String> {
 #[tauri::command]
 pub fn write_markdown_file(path: String, content: String) -> Result<(), String> {
     let p = Path::new(&path);
+
+    if !has_allowed_extension(p) {
+        return Err(format!("Refusing to write a non-text file: {}", path));
+    }
 
     if p.exists() && !p.is_file() {
         return Err(format!("Not a file: {}", path));
@@ -512,6 +536,44 @@ pub fn show_ai_context_menu(
     window.popup_menu(&menu).map_err(|e| e.to_string())?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod fs_scope_tests {
+    use super::{has_allowed_extension, read_markdown_file, write_markdown_file};
+    use std::path::Path;
+
+    #[test]
+    fn text_extensions_are_allowed_case_insensitively() {
+        for ok in ["/x/a.md", "/x/a.MARKDOWN", "/x/a.Txt", "/x/a.mkd", "/x/a.mdx"] {
+            assert!(has_allowed_extension(Path::new(ok)), "{ok} should be allowed");
+        }
+    }
+
+    #[test]
+    fn sensitive_and_extensionless_paths_are_refused() {
+        for bad in [
+            "/home/u/.ssh/id_rsa",
+            "/home/u/.ssh/authorized_keys",
+            "/etc/passwd",
+            "/home/u/.bashrc",
+            "/home/u/a.sh",
+            "/home/u/a.exe",
+            "/home/u/Makefile",
+        ] {
+            assert!(!has_allowed_extension(Path::new(bad)), "{bad} should be refused");
+        }
+    }
+
+    #[test]
+    fn read_and_write_reject_a_non_text_path_before_touching_disk() {
+        // The path does not exist; the extension guard must fire first, so the
+        // error is the refusal, never a "file not found".
+        let err = read_markdown_file("/home/u/.ssh/id_rsa".into()).unwrap_err();
+        assert!(err.contains("Refusing to read"), "got: {err}");
+        let err = write_markdown_file("/root/.ssh/authorized_keys".into(), "x".into()).unwrap_err();
+        assert!(err.contains("Refusing to write"), "got: {err}");
+    }
 }
 
 #[cfg(all(test, windows))]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -21,7 +21,7 @@
       }
     ],
     "security": {
-      "csp": null,
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: asset: http://asset.localhost https:; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost https://raw.githubusercontent.com https://gist.githubusercontent.com https://api.github.com https://github.com https://objects.githubusercontent.com https://codeload.github.com; object-src 'none'; base-uri 'self'; frame-src 'none'; worker-src 'self' blob:",
       "assetProtocol": {
         "enable": true,
         "scope": {

--- a/src/lib/components/MarkdownRenderer.svelte
+++ b/src/lib/components/MarkdownRenderer.svelte
@@ -6,6 +6,7 @@
   import { tocEntries, activeHeadingId, extractToc, isObserverPaused } from "$lib/stores/toc";
   import { aiLookup, setPendingSelection } from "$lib/stores/aiLookup";
   import mermaid from "mermaid";
+  import DOMPurify from "dompurify";
 
   let {
     html = "",
@@ -47,7 +48,10 @@
     mermaid.initialize({
       startOnLoad: false,
       theme,
-      securityLevel: "loose",
+      // #security: strict keeps Mermaid from emitting HTML labels or click-node
+      // JS/URL bindings from untrusted diagram source; the SVG is then sanitized
+      // again below as defense in depth. (Felipe Boralli disclosure, 2026-08-14.)
+      securityLevel: "strict",
       themeVariables: isDark ? {
         primaryColor: "#0A1E2E",
         primaryTextColor: "#e5e5e7",
@@ -84,7 +88,16 @@
         const { svg } = await mermaid.render(id, source);
         const container = document.createElement("div");
         container.className = "mermaid-diagram my-4 flex justify-center";
-        container.innerHTML = svg;
+        // #security: never trust Mermaid's SVG straight into the DOM. Even in
+        // strict mode this is the last gate before an <svg> from an untrusted
+        // document is live — strip <script>, foreignObject and on* handlers,
+        // keep the diagram's shapes, text, styles and marker refs.
+        container.innerHTML = DOMPurify.sanitize(svg, {
+          USE_PROFILES: { svg: true, svgFilters: true },
+          ADD_TAGS: ["use", "style"],
+          ADD_ATTR: ["xmlns", "xmlns:xlink", "xlink:href", "dominant-baseline"],
+          FORBID_TAGS: ["foreignObject"],
+        });
         pre.replaceWith(container);
       } catch {
         // Leave the code block as-is if Mermaid fails

--- a/src/lib/components/MarkdownRenderer.svelte
+++ b/src/lib/components/MarkdownRenderer.svelte
@@ -92,11 +92,28 @@
         // strict mode this is the last gate before an <svg> from an untrusted
         // document is live — strip <script>, foreignObject and on* handlers,
         // keep the diagram's shapes, text, styles and marker refs.
+        // Same allowlist shape as the main pipeline's sanitize call, extended
+        // with the elements Mermaid actually emits. DOMPurify's defaults do the
+        // security work: <script>, on* handlers and javascript: URLs are
+        // dropped, while the diagram's shapes, text, styles and label markup
+        // (which lives in <foreignObject>) survive intact.
         container.innerHTML = DOMPurify.sanitize(svg, {
-          USE_PROFILES: { svg: true, svgFilters: true },
-          ADD_TAGS: ["use", "style"],
-          ADD_ATTR: ["xmlns", "xmlns:xlink", "xlink:href", "dominant-baseline"],
-          FORBID_TAGS: ["foreignObject"],
+          ADD_TAGS: [
+            "svg", "g", "path", "line", "rect", "circle", "ellipse", "polygon",
+            "polyline", "text", "tspan", "defs", "marker", "style", "use",
+            "symbol", "clipPath", "pattern", "linearGradient", "radialGradient",
+            "stop", "filter", "title", "desc", "foreignObject",
+          ],
+          ADD_ATTR: [
+            "class", "style", "xmlns", "xmlns:xlink", "xlink:href", "viewBox",
+            "d", "fill", "stroke", "stroke-width", "stroke-dasharray",
+            "transform", "x", "y", "x1", "x2", "y1", "y2", "cx", "cy", "r",
+            "rx", "ry", "width", "height", "points", "offset", "stop-color",
+            "text-anchor", "dominant-baseline", "font-size", "font-family",
+            "font-weight", "marker-end", "marker-start", "id", "aria-hidden",
+            "aria-roledescription", "focusable", "role", "preserveAspectRatio",
+            "requiredFeatures",
+          ],
         });
         pre.replaceWith(container);
       } catch {


### PR DESCRIPTION
Hardens the renderer and the filesystem commands after a private security review. Not tied to a public issue by design.

## Background

An external reviewer reported privately that Mermaid diagram rendering was the one path in the app that bypassed the HTML sanitizer, and that nothing else contained it: no CSP, and two filesystem commands that accepted any path from the web view.

**Verified before changing anything:** on the Mermaid version we ship (11.14), the reported `<img onerror>` payload is already stripped by Mermaid's *own* internal DOMPurify pass, even in `loose` mode, so it does not execute on today's build. The configuration was still wrong: `loose` is documented as unsafe for untrusted input, our code inserted Mermaid's SVG with no sanitizer of our own, and there was no second layer behind it. All of it is fixed here.

## What changes

**1. Mermaid — two layers where there were none.**
`securityLevel` moves from `loose` to `strict`, so Mermaid will not emit HTML labels or `click`-node JS/URL bindings from diagram source. The rendered SVG is then passed through DOMPurify before it reaches the DOM, using the same allowlist shape as the main pipeline. `<script>`, `on*` handlers and `javascript:` URLs are dropped; shapes, text, styles, marker refs and label markup survive.

**2. A real Content-Security-Policy** replaces `csp: null`: `script-src 'self'` (no injected script can run), `connect-src` limited to self plus the GitHub hosts the URL-open and updater features actually use, `object-src 'none'`, `base-uri 'self'`, `frame-src 'none'`. Tauri injects its own ipc/asset sources on top.

**3. The filesystem commands are bounded.** `read_markdown_file` and `write_markdown_file` refuse any path whose extension is not a markdown/text type, before touching disk, so neither can be turned into an arbitrary-file read or write primitive.

The report's asset-scope suggestion was already implemented in #101.

## Scope and honesty about what this does *not* do

- **`img-src` still allows `https:`**, because remote images in ordinary markdown must keep working. An image request is therefore still a possible data-egress channel for any script that manages to run. This PR closes script execution and `fetch()` egress; it does not claim to close image-based egress.
- **`opener:allow-open-path` stays `**`.** Opening a document's linked PDFs and images (#30) needs it, the JS side already refuses executable types, and changes 1 and 2 remove the path that reached it. Narrowing it to a pinned-vault model is a separate design.

## Behaviour change

Files without an extension can no longer be opened or saved. This is the same property that refuses `~/.ssh/id_rsa` and `authorized_keys`, since both are extensionless, so the security benefit and the cost are one mechanism. `.md`, `.markdown`, `.mdown`, `.mkd`, `.mdx`, `.txt` and `.text` are unaffected, and the file-open dialog already filters to those. The reachable routes for an extensionless file are drag-and-drop and the CLI; both now show a clear message naming the file and the reason. Kept deliberately.

## Evidence

- **3 Rust unit tests** on the extension guard: allowed types case-insensitively, sensitive/extensionless paths refused, and read/write both refuse before the not-found check. `cargo test` 26/26. Gate 102/102, types clean.
- **Mermaid regression sweep across all 20 diagram types** (flowchart, sequence, class, state, ER, journey, gantt, pie, quadrant, requirement, gitGraph, mindmap, timeline, sankey, xychart, block, C4, kanban, architecture, packet): 20/20 render, 20/20 keep their labels, 0 produce unsafe markup. This caught a real regression in the first cut, which forbade `foreignObject` outright and emptied every diagram's labels; fixed in the second commit.
- **Security payload battery**, 15 attack shapes including Mermaid HTML-label and `click`-binding vectors, SVG `onload`, `javascript:` and `data:` links, iframe, object/embed, form, meta-refresh and base: nothing executed, and the DOM contains zero scripts, iframes, objects, forms, meta/base elements, `on*` handlers or `javascript:` hrefs.
- **CSP verified in a real webview**, which required `tauri build --debug` because Tauri serves the policy as a header from its embedded-asset protocol and applies nothing in dev. App loads, KaTeX and its bundled fonts render, all 20 diagram types render, local asset-protocol images and remote https images load, highlight.js styling applies, and no CSP violations appear in stderr or the system log. **Proof the policy is live rather than absent:** removing `https:` from `img-src` and rebuilding blocked the remote image; restoring it brought it back.
