### PR TITLE
5 small daily-use fixes: scrollbar width, wide-mode margins, ==highlight== support, reading-position bug, Cmd+A/Ctrl+wheel

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   <img alt="MDHero" src=".github/assets/banner-light.png" width="100%">
 </picture>
 <br>
-A beautiful, native Markdown viewer and lightweight editor for macOS and Windows. ~8MB. Free. Open source.
+A beautiful, native Markdown viewer and lightweight editor for macOS, Windows and Linux. ~8MB. Free. Open source.
 <br><br>
 
 [![GitHub Stars](https://img.shields.io/github/stars/vaibhav-kakde-in/mdhero?style=flat-square)](https://github.com/vaibhav-kakde-in/mdhero/stargazers)
@@ -13,6 +13,7 @@ A beautiful, native Markdown viewer and lightweight editor for macOS and Windows
 [![License](https://img.shields.io/github/license/vaibhav-kakde-in/mdhero?style=flat-square)](LICENSE)
 ![macOS](https://img.shields.io/badge/macOS-supported-blue?style=flat-square&logo=apple)
 ![Windows](https://img.shields.io/badge/Windows-supported-blue?style=flat-square&logo=windows)
+![Linux](https://img.shields.io/badge/Linux-supported-blue?style=flat-square&logo=linux)
 [![Built with Tauri](https://img.shields.io/badge/Built_with-Tauri-FFC131?style=flat-square&logo=tauri)](https://tauri.app)
 
 [Download](https://github.com/vaibhav-kakde-in/mdhero/releases/latest) · [Website](https://mdhero.app) · [Discussions](https://github.com/vaibhav-kakde-in/mdhero/discussions)

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "mark.js": "^8.11.1",
     "markdown-it": "^14.1.1",
     "markdown-it-anchor": "^9.2.0",
+    "markdown-it-mark": "^4.0.0",
     "markdown-it-task-lists": "^2.1.1",
     "markdown-it-texmath": "^1.0.0",
     "mermaid": "^11.14.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       markdown-it-anchor:
         specifier: ^9.2.0
         version: 9.2.0(@types/markdown-it@14.1.2)(markdown-it@14.1.1)
+      markdown-it-mark:
+        specifier: ^4.0.0
+        version: 4.0.0
       markdown-it-task-lists:
         specifier: ^2.1.1
         version: 2.1.1
@@ -1490,6 +1493,9 @@ packages:
     peerDependencies:
       '@types/markdown-it': '*'
       markdown-it: '*'
+
+  markdown-it-mark@4.0.0:
+    resolution: {integrity: sha512-YLhzaOsU9THO/cal0lUjfMjrqSMPjjyjChYM7oyj4DnyaXEzA8gnW6cVJeyCrCVeyesrY2PlEdUYJSPFYL4Nkg==}
 
   markdown-it-task-lists@2.1.1:
     resolution: {integrity: sha512-TxFAc76Jnhb2OUu+n3yz9RMu4CwGfaT788br6HhEDlvWfdeJcLUsxk1Hgw2yJio0OXsxv7pyIPmvECY7bMbluA==}
@@ -3008,6 +3014,8 @@ snapshots:
     dependencies:
       '@types/markdown-it': 14.1.2
       markdown-it: 14.1.1
+
+  markdown-it-mark@4.0.0: {}
 
   markdown-it-task-lists@2.1.1: {}
 

--- a/src/app.css
+++ b/src/app.css
@@ -39,8 +39,8 @@ html.dark {
 
 /* Scrollbar styling */
 ::-webkit-scrollbar {
-  width: 6px;
-  height: 6px;
+  width: 15px;
+  height: 15px;
 }
 
 ::-webkit-scrollbar-track {

--- a/src/lib/components/MarkdownRenderer.svelte
+++ b/src/lib/components/MarkdownRenderer.svelte
@@ -462,6 +462,19 @@
     color: #aeaeb2;
   }
 
+  /* Highlight (==text==, markdown-it-mark) */
+  article :global(mark) {
+    background: #FEF08A;
+    color: #1c1c1e;
+    padding: 0.05em 0.2em;
+    border-radius: 3px;
+  }
+
+  :global(html.dark) article :global(mark) {
+    background: #A16207;
+    color: #FEF9C3;
+  }
+
   /* Blockquotes */
   article :global(blockquote) {
     border-left: 3px solid #0891B2;

--- a/src/lib/components/SettingsDialog.svelte
+++ b/src/lib/components/SettingsDialog.svelte
@@ -70,6 +70,19 @@
               class="setting-switch"
             />
           </label>
+
+          <label class="setting-row">
+            <div class="setting-text">
+              <span class="setting-label">Remember reading position</span>
+              <span class="setting-hint">Reopening a previously viewed file scrolls back to where you left off.</span>
+            </div>
+            <input
+              type="checkbox"
+              checked={$settings.rememberReadingPosition}
+              onchange={(e) => settings.update((s) => ({ ...s, rememberReadingPosition: e.currentTarget.checked }))}
+              class="setting-switch"
+            />
+          </label>
         </section>
 
         <section class="settings-section">

--- a/src/lib/renderer/markdown-it-mark.d.ts
+++ b/src/lib/renderer/markdown-it-mark.d.ts
@@ -1,0 +1,1 @@
+declare module "markdown-it-mark";

--- a/src/lib/renderer/pipeline.ts
+++ b/src/lib/renderer/pipeline.ts
@@ -3,6 +3,7 @@ import DOMPurify from "dompurify";
 import taskLists from "markdown-it-task-lists";
 import anchor from "markdown-it-anchor";
 import texmath from "markdown-it-texmath";
+import mark from "markdown-it-mark";
 import katex from "katex";
 import hljs from "highlight.js/lib/core";
 import { convertFileSrc } from "@tauri-apps/api/core";
@@ -233,6 +234,7 @@ export async function initRenderer(): Promise<void> {
     delimiters: "dollars",
   });
 
+  md.use(mark);
   md.use(taskLists, { enabled: false, label: true });
   md.use(anchor, {
     permalink: false,
@@ -273,6 +275,7 @@ export function renderFull(markdown: string, baseDir?: string): RenderResult {
     },
   });
     md.use(texmath, { engine: katex, delimiters: "dollars" });
+    md.use(mark);
     md.use(taskLists, { enabled: false, label: true });
     md.use(anchor, {
       permalink: false,

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -12,6 +12,8 @@ export interface ReaderSettings {
   autoPresentMarp: boolean;
   /** Reopen the files that were open when the app last ran (#72). */
   restoreTabsOnLaunch: boolean;
+  /** Restore the last scroll position when reopening a previously viewed file. */
+  rememberReadingPosition: boolean;
 }
 
 const STORAGE_KEY = "mdhero-settings";
@@ -38,6 +40,7 @@ function loadSettings(): ReaderSettings {
     showLineNumbers: true,
     autoPresentMarp: true,
     restoreTabsOnLaunch: true,
+    rememberReadingPosition: true,
   };
 
   if (typeof localStorage === "undefined") return defaults;

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -18,7 +18,10 @@ const STORAGE_KEY = "mdhero-settings";
 const DEFAULT_MAX_WIDTH = 720;
 const MIN_MAX_WIDTH = 560;
 const MAX_MAX_WIDTH = 3840;
-const WIDE_MAX_WIDTH = "min(3840px, calc(100vw - clamp(48px, 8vw, 128px)))";
+// The article itself already carries 32px of side padding (Tailwind `px-8`
+// in MarkdownRenderer.svelte) for breathing room against its own edge — this
+// only needs to hand it the full available width, not subtract more on top.
+const WIDE_MAX_WIDTH = "100%";
 
 function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));

--- a/src/lib/utils/scroll-sync.ts
+++ b/src/lib/utils/scroll-sync.ts
@@ -17,8 +17,19 @@ export type ViewMode = "viewer" | "raw" | "editor";
 
 const TOOLBAR_TABBAR_HEIGHT = 80; // approximate sticky chrome at top
 
-/** Read the source line currently anchored at the top of the viewport. */
+/**
+ * Read the source line currently anchored at the top of the viewport, or -1
+ * if that can't be measured right now.
+ *
+ * A collapsed viewport (window minimized, or hidden right as the OS tears
+ * down layout) makes every `getBoundingClientRect()` in `readViewerLine`
+ * report a zero-size rect. That was being misread as "scrolled past the
+ * last element" and saved as the reading-progress line — so minimizing the
+ * window while reading, then reopening the file later, jumped straight to
+ * the end regardless of where the user actually was. Bail out instead.
+ */
 export function getCurrentSourceLine(mode: ViewMode): number {
+  if (window.innerWidth === 0 || window.innerHeight === 0) return -1;
   if (mode === "viewer") return readViewerLine();
   if (mode === "raw") return readRawLine();
   return readEditorLine();

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -94,6 +94,7 @@
 
   function handleScrollForProgress() {
     if (isRestoring) return;
+    if (!$settings.rememberReadingPosition) return;
     const tab = tabStore.getActiveTab();
     if (!tab || tab.isEditing) return;
     if (tab.filePath.startsWith("paste://")) return;
@@ -103,18 +104,21 @@
       // Tiny-file edge case: skip save if document fits in viewport
       if (document.documentElement.scrollHeight <= window.innerHeight) return;
       const line = getCurrentSourceLine("viewer");
+      if (line < 0) return; // viewport collapsed (e.g. window minimized) — don't clobber saved progress
       saveProgress(tab.filePath, line);
     }, 500);
   }
 
   function saveProgressNow() {
     clearTimeout(scrollSaveTimer);
+    if (!$settings.rememberReadingPosition) return;
     const tab = tabStore.getActiveTab();
     if (!tab || tab.isEditing) return;
     if (tab.filePath.startsWith("paste://")) return;
     // Tiny-file edge case: skip save if document fits in viewport
     if (document.documentElement.scrollHeight <= window.innerHeight) return;
     const line = getCurrentSourceLine("viewer");
+    if (line < 0) return; // viewport collapsed (e.g. window minimized) — don't clobber saved progress
     saveProgress(tab.filePath, line);
   }
 
@@ -1113,7 +1117,7 @@
         window.scrollTo(0, savedScroll);
         // Restore reading progress (smooth-scroll to saved source line)
         // Only if the tab is at scroll 0 (freshly opened or re-opened)
-        if (savedScroll === 0) {
+        if (savedScroll === 0 && $settings.rememberReadingPosition) {
           restoreProgress(tab.filePath);
         }
       });

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -668,6 +668,7 @@
     // Safety net: if focus leaves while j/k is held, keyup may never fire — stop the loop.
     window.addEventListener("blur", stopScroll);
     window.addEventListener("scroll", handleScrollForProgress, { passive: true });
+    window.addEventListener("wheel", handleWheel, { passive: false });
     window.addEventListener("beforeunload", saveProgressNow);
     document.addEventListener("visibilitychange", handleVisibilityChange);
 
@@ -715,6 +716,7 @@
       window.removeEventListener("blur", stopScroll);
       stopScroll();
       window.removeEventListener("scroll", handleScrollForProgress);
+      window.removeEventListener("wheel", handleWheel);
       window.removeEventListener("beforeunload", saveProgressNow);
       document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
@@ -788,6 +790,16 @@
 
     updateScrollDirection();
     if (scrollDir === 0) stopScroll();
+  }
+
+  /** Ctrl/Cmd+wheel zoom — same font-size adjustment as Cmd+Plus/Minus, just
+   * driven by the mouse wheel instead of the keyboard. `preventDefault` stops
+   * the browser's own page-zoom/scroll on the ctrl+wheel gesture. */
+  function handleWheel(e: WheelEvent) {
+    if (!e.ctrlKey) return;
+    e.preventDefault();
+    const delta = e.deltaY < 0 ? 1 : -1;
+    settings.update((s) => ({ ...s, fontSize: Math.min(32, Math.max(10, s.fontSize + delta)) }));
   }
 
   function isInputFocused(): boolean {
@@ -889,6 +901,23 @@
     if ((e.metaKey || e.ctrlKey) && e.key === "0") {
       e.preventDefault();
       settings.update((s) => ({ ...s, fontSize: 17 }));
+      return;
+    }
+
+    // Cmd+A select-all — scoped to the rendered document, not the whole app
+    // chrome (toolbar, tab bar...). Left to the browser default (which would
+    // select the entire page, menus included) inside inputs/editor, where a
+    // normal text-field select-all is exactly what's wanted.
+    if ((e.metaKey || e.ctrlKey) && e.key === "a" && !isInputFocused() && !activeTab?.isEditing) {
+      const target = document.querySelector("article.prose, pre.raw-source");
+      if (target) {
+        e.preventDefault();
+        const range = document.createRange();
+        range.selectNodeContents(target);
+        const sel = window.getSelection();
+        sel?.removeAllRanges();
+        sel?.addRange(range);
+      }
       return;
     }
 


### PR DESCRIPTION
## Summary
Five small independent fixes/features found while using MDHero daily to browse a large CLAUDE.md documentation hierarchy:

- **Scrollbar width**: bumped from 6px to 15px — the old one was hard to grab, especially on the Table of Contents panel, and even harder on a touchscreen.
- **Wide content-width mode**: fixed stacked margins (the vw-based margin calc was on top of the article's own padding), so Wide now actually uses the full available width.
- **`==text==` highlight syntax**: wasn't supported at all (html:false blocks the raw-HTML alternative too). Added markdown-it-mark + themed `<mark>` styling.
- **Reading-position restore bug**: minimizing the window while reading corrupted the saved scroll position to "end of file" (getBoundingClientRect returns zero-size rects on a collapsed viewport). Fixed, plus added a Settings toggle to disable the whole feature.
- **Cmd/Ctrl+A** was selecting the entire page chrome instead of just the document; **Ctrl+wheel** now zooms like Cmd+Plus/Minus.

Each fix is its own commit with a detailed message. Happy to split into separate PRs if that's easier to review.

## Test plan
- [x] `svelte-check`: 0 new errors
- [x] `vite build`: succeeds
- [x] Manually tested each fix in a local debug build