### PR TITLE
feat: line numbers in the raw markdown view (#110)

### DIFF
--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -2,6 +2,7 @@
   import { onMount, onDestroy, tick } from "svelte";
   import { searchQuery, searchActiveIndex, searchTotal } from "$lib/stores/search";
   import { findMatches, buildHighlightHtml } from "$lib/utils/text-search";
+  import { gutterHtml as buildGutterHtml, gutterWidth as buildGutterWidth, lineCount as countLines } from "$lib/utils/line-gutter";
 
   let {
     value,
@@ -42,28 +43,10 @@
   // line's block has the same height as in the textarea and its number — a CSS
   // counter on the block — lines up with the block's top, even when the line
   // soft-wraps to several rows (continuation rows get no number, like a
-  // wrapping code editor). No JS height measuring needed.
-  const escapeHtml = (s: string) =>
-    s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-  const lineCount = $derived(localValue.split("\n").length);
-  // Width the digits need; monospace so `ch` is exact. Min 2 digits + a gap.
-  const gutterWidth = $derived(`calc(${Math.max(2, String(lineCount).length)}ch + 16px)`);
-  // ponytail: rebuilds all line blocks on each caret move (for the active-line
-  // class). O(lines) per keystroke — fine for typical docs; switch to a single
-  // positioned highlight bar if it ever lags on very large files.
-  const gutterHtml = $derived(
-    showLineNumbers
-      ? localValue
-          // Empty lines would collapse to zero height and desync the count, so
-          // give them a zero-width space to reserve exactly one line box.
-          .split("\n")
-          .map(
-            (l, i) =>
-              `<div class="gl${i === activeLine ? " active" : ""}">${escapeHtml(l) || "​"}</div>`
-          )
-          .join("")
-      : ""
-  );
+  // wrapping code editor). No JS height measuring needed. The raw view (#110)
+  // shares the same helpers.
+  const lineCount = $derived(countLines(localValue));
+  const gutterWidth = $derived(buildGutterWidth(lineCount));
 
   // --- Find-in-editor highlight backdrop --------------------------------------
   // mark.js can't highlight a <textarea> (its contents aren't markable DOM text),
@@ -131,6 +114,11 @@
   // Which logical line the caret is on, for the current-line highlight. Read
   // from selectionStart on every caret move (input, click, arrow keys, focus).
   let activeLine = $state(0);
+
+  // Rebuilt on each caret move so the active line can be marked. O(lines) per
+  // keystroke — fine for typical docs; switch to a single positioned highlight
+  // bar if it ever lags on very large files.
+  const gutterHtml = $derived(showLineNumbers ? buildGutterHtml(localValue, activeLine) : "");
   function updateActiveLine() {
     if (!textareaEl) return;
     activeLine = localValue.slice(0, textareaEl.selectionStart).split("\n").length - 1;

--- a/src/lib/utils/line-gutter.ts
+++ b/src/lib/utils/line-gutter.ts
@@ -1,0 +1,56 @@
+/**
+ * Line-number gutter helpers, shared by the editor (#53) and the raw markdown
+ * view (#110).
+ *
+ * Both panes render the numbers the same way: a transparent mirror element that
+ * wraps identically to the text it shadows (same font, content width and
+ * wrapping rules), with one block per logical line and a CSS counter drawing the
+ * number. Because the mirror wraps the same way, a soft-wrapped line occupies
+ * the same height in both layers and its number stays aligned with the line's
+ * first row — no JS height measuring.
+ *
+ * The editor needs a mirror because a `<textarea>` cannot carry per-line
+ * decorations. The raw view uses one for a different reason: `scroll-sync`
+ * measures that pane via `pre.textContent`, and `textContent` puts no newlines
+ * between block elements, so splitting the source into per-line elements would
+ * silently corrupt line-anchored scrolling.
+ */
+
+const escapeHtml = (s: string): string =>
+  s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+
+/** Zero-width space: keeps an empty line's block one line-box tall instead of
+ *  collapsing to zero height, which would desync every number below it. */
+const EMPTY_LINE = "​";
+
+/**
+ * CSS width the gutter column needs for `lineCount` numbers.
+ *
+ * Monospace, so `ch` is exact. Always reserves at least two digits so the
+ * column does not visibly resize between line 9 and line 10.
+ */
+export function gutterWidth(lineCount: number): string {
+  return `calc(${Math.max(2, String(Math.max(1, lineCount)).length)}ch + 16px)`;
+}
+
+/**
+ * Builds the mirror's inner HTML: one `div.gl` per logical line.
+ *
+ * @param text Source text the gutter shadows.
+ * @param activeLine Zero-based line to mark with `.gl.active`, or `-1` for none
+ *   (the raw view has no caret, so it passes `-1`).
+ */
+export function gutterHtml(text: string, activeLine = -1): string {
+  return text
+    .split("\n")
+    .map(
+      (line, i) =>
+        `<div class="gl${i === activeLine ? " active" : ""}">${escapeHtml(line) || EMPTY_LINE}</div>`
+    )
+    .join("");
+}
+
+/** Number of logical lines in `text`. */
+export function lineCount(text: string): number {
+  return text.split("\n").length;
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -51,6 +51,7 @@
   import { checkForUpdates, updateAvailable, updateDismissed, checkInFlight } from "$lib/stores/updater";
   import { get } from "svelte/store";
   import { getCurrentSourceLine, scrollToSourceLine, type ViewMode } from "$lib/utils/scroll-sync";
+  import { gutterHtml, gutterWidth, lineCount } from "$lib/utils/line-gutter";
   import { saveProgress, getProgress } from "$lib/stores/readingProgress";
 
   let rendererReady = $state(false);
@@ -72,6 +73,12 @@
   let splitPreviewHtml = $state("");
   let splitPreviewTimer: ReturnType<typeof setTimeout> | undefined;
   let contentMaxWidth = $derived(getContentMaxWidth($settings));
+
+  // Raw-view line numbers (#110). Same gutter treatment as the editor, driven by
+  // the same `showLineNumbers` setting so the two views agree.
+  let rawGutterOn = $derived($settings.showLineNumbers);
+  let rawGutterWidth = $derived(gutterWidth(lineCount($docStore.content)));
+  let rawGutterHtml = $derived(rawGutterOn ? gutterHtml($docStore.content) : "");
 
   // Lightbox state
   let lightboxVisible = $state(false);
@@ -1213,10 +1220,28 @@
       />
     {:else if rawMode}
       <main class="content-main" class:toc-spaced={$tocVisible && $tocEntries.length > 0}>
-        <pre
-          class="raw-source"
-          style="font-size: {$settings.fontSize}px; line-height: {$settings.lineHeight}; max-width: {contentMaxWidth};"
-        ><code>{$docStore.content}</code></pre>
+        <div
+          class="raw-stack"
+          class:with-gutter={rawGutterOn}
+          style="max-width: {contentMaxWidth}; --gutter-w: {rawGutterWidth};"
+        >
+          {#if rawGutterOn}
+            <!-- Transparent mirror wrapping identically to the <pre>; CSS
+                 counters on each line block draw the numbers. Kept out of the
+                 <pre> so `scroll-sync` still reads the source from its
+                 textContent. -->
+            <div
+              class="raw-gutter"
+              aria-hidden="true"
+              style="font-size: {$settings.fontSize}px; line-height: {$settings.lineHeight};"
+            >{@html rawGutterHtml}</div>
+          {/if}
+          <pre
+            class="raw-source"
+            class:with-gutter={rawGutterOn}
+            style="font-size: {$settings.fontSize}px; line-height: {$settings.lineHeight};"
+          ><code>{$docStore.content}</code></pre>
+        </div>
       </main>
     {:else}
       <main class="content-main" class:toc-spaced={$tocVisible && $tocEntries.length > 0}>
@@ -1314,8 +1339,13 @@
     padding-left: 240px;
   }
 
-  .raw-source {
+  .raw-stack {
+    position: relative;
     margin: 0 auto;
+  }
+
+  .raw-source {
+    margin: 0;
     padding: 24px 32px;
     font-family: "SF Mono", "JetBrains Mono", Menlo, monospace;
     color: #1c1c1e;
@@ -1327,5 +1357,66 @@
 
   :global(html.dark) .raw-source {
     color: #d1d1d6;
+  }
+
+  /* Line-number gutter (#110). The <pre> gains left padding to open the column;
+     `measureLineOffsets` reads that padding off the element, so line-anchored
+     scroll sync follows the narrower text automatically. */
+  .raw-source.with-gutter {
+    padding-left: calc(32px + var(--gutter-w));
+  }
+
+  /* Mirror of the <pre>: identical box, font and wrapping, transparent text.
+     Only the CSS counters on each line block are visible. */
+  .raw-gutter {
+    position: absolute;
+    inset: 0;
+    margin: 0;
+    padding: 24px 32px 24px calc(32px + var(--gutter-w));
+    font-family: "SF Mono", "JetBrains Mono", Menlo, monospace;
+    white-space: pre-wrap;
+    word-break: break-word;
+    box-sizing: border-box;
+    color: transparent;
+    pointer-events: none;
+    user-select: none;
+    overflow: hidden;
+    counter-reset: gl;
+  }
+
+  .raw-gutter :global(.gl) {
+    counter-increment: gl;
+    position: relative;
+  }
+
+  .raw-gutter :global(.gl)::before {
+    content: counter(gl);
+    position: absolute;
+    left: calc(-1 * var(--gutter-w));
+    width: calc(var(--gutter-w) - 8px);
+    text-align: right;
+    color: #b0b0b5;
+  }
+
+  :global(html.dark) .raw-gutter :global(.gl)::before {
+    color: #5a5a5e;
+  }
+
+  /* Faint tint + hairline divider for the gutter column, matching the editor. */
+  .raw-stack.with-gutter::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 32px;
+    width: var(--gutter-w);
+    background: rgba(0, 0, 0, 0.02);
+    border-right: 1px solid rgba(0, 0, 0, 0.06);
+    pointer-events: none;
+  }
+
+  :global(html.dark) .raw-stack.with-gutter::before {
+    background: rgba(255, 255, 255, 0.025);
+    border-right-color: rgba(255, 255, 255, 0.08);
   }
 </style>

--- a/tests/unit/line-gutter.test.ts
+++ b/tests/unit/line-gutter.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { gutterHtml, gutterWidth, lineCount } from "../../src/lib/utils/line-gutter";
+
+describe("lineCount", () => {
+  it("counts a single line with no trailing newline", () => {
+    expect(lineCount("only line")).toBe(1);
+  });
+
+  it("counts the empty document as one line", () => {
+    expect(lineCount("")).toBe(1);
+  });
+
+  it("counts the empty line a trailing newline creates", () => {
+    expect(lineCount("a\nb\n")).toBe(3);
+  });
+});
+
+describe("gutterWidth", () => {
+  it("reserves two digits even for short documents", () => {
+    expect(gutterWidth(1)).toBe("calc(2ch + 16px)");
+    expect(gutterWidth(9)).toBe("calc(2ch + 16px)");
+    expect(gutterWidth(99)).toBe("calc(2ch + 16px)");
+  });
+
+  it("grows with the digit count so numbers never clip", () => {
+    expect(gutterWidth(100)).toBe("calc(3ch + 16px)");
+    expect(gutterWidth(1000)).toBe("calc(4ch + 16px)");
+  });
+
+  it("does not collapse below two digits for an empty document", () => {
+    expect(gutterWidth(0)).toBe("calc(2ch + 16px)");
+  });
+});
+
+describe("gutterHtml", () => {
+  it("emits one block per logical line", () => {
+    expect(gutterHtml("a\nb\nc")).toBe(
+      '<div class="gl">a</div><div class="gl">b</div><div class="gl">c</div>'
+    );
+  });
+
+  it("escapes markup so source text cannot inject nodes into the mirror", () => {
+    expect(gutterHtml('<img src=x onerror="alert(1)"> & <b>')).toBe(
+      '<div class="gl">&lt;img src=x onerror="alert(1)"&gt; &amp; &lt;b&gt;</div>'
+    );
+  });
+
+  it("gives empty lines a zero-width space so they keep one line box", () => {
+    // Without this the block collapses to zero height and every number below it
+    // drifts out of alignment with the text.
+    expect(gutterHtml("a\n\nb")).toBe(
+      '<div class="gl">a</div><div class="gl">​</div><div class="gl">b</div>'
+    );
+  });
+
+  it("marks the active line when one is given", () => {
+    expect(gutterHtml("a\nb", 1)).toBe(
+      '<div class="gl">a</div><div class="gl active">b</div>'
+    );
+  });
+
+  it("marks no line active by default, as the raw view has no caret", () => {
+    expect(gutterHtml("a\nb")).not.toContain("active");
+  });
+
+  it("keeps the block count equal to the line count", () => {
+    const text = "one\n\nthree\nfour\n";
+    const blocks = gutterHtml(text).match(/<div class="gl/g) ?? [];
+    expect(blocks.length).toBe(lineCount(text));
+  });
+});


### PR DESCRIPTION
## Summary

Raw view now shows the same line-number gutter as the editor, driven by the same `showLineNumbers` setting. Closes #110.

Line numbers only existed in edit mode, so the same document had a gutter in one view and not the other — even though raw view is where line numbers are most often wanted, for pointing someone at "line 214".

## Changes

- `src/lib/utils/line-gutter.ts` (new): `gutterWidth`, `gutterHtml` and `lineCount`, lifted out of `Editor.svelte` so both views share one implementation instead of a second copy of the width formula and the HTML escaping.
- `src/routes/+page.svelte`: the raw view renders the gutter, using the same mirror technique as the editor.
- `src/lib/components/Editor.svelte`: now calls the shared helpers (−19 / +6). Behaviour is unchanged.
- `tests/unit/line-gutter.test.ts` (new): 12 tests.

### Why a mirror element rather than one element per line

Splitting the source into per-line elements is the obvious implementation, and it silently breaks scroll sync.

`scroll-sync` locates the raw pane with `document.querySelector(".raw-source")` and reads it through `pre.textContent`. `textContent` puts no newlines between block elements, so per-line elements would collapse the whole document into one long line and every line-anchored scroll would land in the wrong place. `scroll-sync.ts` even says as much in its header comment: *"Raw and editor have no per-line DOM."*

So the numbers come from a transparent mirror that wraps identically to the `<pre>`, and the `<pre>` keeps exactly the children it had before. The gutter column is opened with left padding on the `<pre>`; `measureLineOffsets` reads that padding off the element via `getComputedStyle`, so line anchoring follows the narrower text with no further changes.

### One thing worth a maintainer's opinion

Touching `Editor.svelte` is slightly beyond what the issue asked for. I extracted the helpers rather than copying the width formula and escaping into a second place, but if you would rather keep the editor untouched and inline the logic in the raw view, say so and I will rework it.

## Testing

- [x] Tested in dev mode (`pnpm tauri dev`)
- [ ] Works in both light and dark mode
- [x] No regressions in existing features
- [x] `pnpm check` passes

`pnpm test`: 14 files, 114 tests pass (102 before this change, 12 added). `pnpm check`: 0 errors.

Verified by hand on a 109-line document covering the three cases the gutter has to get right:

- a paragraph that soft-wraps to ~14 visual rows gets **exactly one number, on its first row**, with continuation rows unnumbered
- consecutive blank lines each keep one line box and their own number
- the column widens from two digits to three at line 100 without the numbers shifting

The editor gutter was re-checked on the same document after the refactor — same wrapping, blank-line and digit-width behaviour as before.

**Dark mode is the one box I have not ticked.** The dark rules are written, mirroring the editor's (`#5a5a5e` numbers and a lighter column tint under `:global(html.dark)`), but I have only looked at light mode, so I would rather not claim it.

## Screenshots
<img width="2525" height="2343" alt="110-raw-gutter-3digits" src="https://github.com/user-attachments/assets/76474ed5-4183-48de-a7e0-0f18a5150545" />
<img width="2515" height="2317" alt="110-raw-gutter-wrapping" src="https://github.com/user-attachments/assets/81dcf26a-5dc5-4130-ab4c-4835dfd9b99c" />



Raw view: the wrapping paragraph on line 7 taking a single number, and the two-to-three digit transition at line 100.
