### PR TITLE
fix(quicklook): address all findings from the #115 security review

### DIFF
--- a/quicklook/Preview.swift
+++ b/quicklook/Preview.swift
@@ -23,6 +23,9 @@ final class PreviewViewController: NSViewController, QLPreviewingController,
     /// Releasing it early is what produces a blank preview.
     private var pending: ((Error?) -> Void)?
     private var webView: WKWebView!
+    /// Set immediately before the one `loadHTMLString` this view ever performs,
+    /// and consumed by the navigation policy below. See `decidePolicyFor`.
+    private var expectingInitialLoad = false
 
     // MARK: - View
 
@@ -52,7 +55,9 @@ final class PreviewViewController: NSViewController, QLPreviewingController,
     func preparePreviewOfFile(at url: URL, completionHandler handler: @escaping (Error?) -> Void) {
         pending = handler
         do {
-            webView.loadHTMLString(try page(for: url), baseURL: nil)
+            let html = try page(for: url)
+            expectingInitialLoad = true
+            webView.loadHTMLString(html, baseURL: nil)
         } catch {
             NSLog("MDHeroQuickLook: %@", error.localizedDescription)
             pending = nil
@@ -75,7 +80,7 @@ final class PreviewViewController: NSViewController, QLPreviewingController,
         // #security: a fresh nonce per preview. preview.html's script-src is
         // nonce-based rather than 'unsafe-inline', so a script that somehow
         // survived the sanitizer still cannot execute.
-        let nonce = Self.makeNonce()
+        let nonce = try Self.makeNonce()
         html = html.replacingOccurrences(of: "__CSP_NONCE__", with: nonce)
 
         // Substitution happens at unique tokens, never at `</head>` or
@@ -120,10 +125,17 @@ final class PreviewViewController: NSViewController, QLPreviewingController,
 
     // MARK: - Helpers
 
-    private static func makeNonce() -> String {
+    /// #security: a failed draw must not silently yield 16 zero bytes — that
+    /// would make the CSP nonce predictable, which is the one property it has.
+    private static func makeNonce() throws -> String {
         var bytes = Data(count: 16)
-        _ = bytes.withUnsafeMutableBytes {
+        let status = bytes.withUnsafeMutableBytes {
             SecRandomCopyBytes(kSecRandomDefault, 16, $0.baseAddress!)
+        }
+        guard status == errSecSuccess else {
+            throw NSError(domain: "MDHeroQuickLook", code: Int(status), userInfo: [
+                NSLocalizedDescriptionKey: "could not generate a CSP nonce (SecRandomCopyBytes \(status))",
+            ])
         }
         return bytes.base64EncodedString().replacingOccurrences(of: "=", with: "")
     }
@@ -151,6 +163,29 @@ final class PreviewViewController: NSViewController, QLPreviewingController,
         default:
             break
         }
+    }
+
+    /// #security: a preview is a viewer, not a browser. Only the in-memory
+    /// document this controller loads is allowed to navigate.
+    ///
+    /// The CSP stops script, forms and `base-uri`, but no CSP directive stops a
+    /// plain link click — and DOMPurify quite correctly leaves `https:` links
+    /// in the document. Following one would navigate this web view out to an
+    /// attacker-chosen URL from a process holding
+    /// `com.apple.security.network.client`, turning any previewed file into a
+    /// beacon: the reader's IP, the time, and the fact that this document was
+    /// opened. Links are therefore dead in the preview; open the file in MDHero
+    /// to follow them.
+    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction,
+                 decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+        if expectingInitialLoad, navigationAction.navigationType == .other {
+            expectingInitialLoad = false
+            decisionHandler(.allow)
+            return
+        }
+        NSLog("MDHeroQuickLook: blocked navigation to %@",
+              navigationAction.request.url?.absoluteString ?? "(none)")
+        decisionHandler(.cancel)
     }
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {

--- a/quicklook/build-appex.sh
+++ b/quicklook/build-appex.sh
@@ -42,11 +42,21 @@ lipo -create -output "$APPEX/Contents/MacOS/MDHeroQuickLook" \
 rm -f "$OUT/MDHeroQuickLook-arm64" "$OUT/MDHeroQuickLook-x86_64"
 
 echo "==> Assembling the bundle"
-sed "s/__VERSION__/$VERSION/g" "$ROOT/quicklook/Info.plist" > "$APPEX/Contents/Info.plist"
+# PlistBuddy rather than sed: the version comes from package.json, and a `/` in
+# it would corrupt a sed expression. This also fails loudly if a key is missing.
+cp "$ROOT/quicklook/Info.plist" "$APPEX/Contents/Info.plist"
+/usr/libexec/PlistBuddy \
+  -c "Set :CFBundleShortVersionString $VERSION" \
+  -c "Set :CFBundleVersion $VERSION" \
+  "$APPEX/Contents/Info.plist" > /dev/null
 cp "$ROOT/build-quicklook/preview.html" "$APPEX/Contents/Resources/preview.html"
 plutil -lint "$APPEX/Contents/Info.plist" > /dev/null
 
-echo "==> Signing with identity: $IDENTITY"
+# Deliberately does not echo $IDENTITY: it comes from a secret in CI. GitHub
+# would mask it, and the identity is recoverable from any shipped binary via
+# `codesign -dv` anyway — but echoing secret-sourced values is the habit that
+# leaks the day someone pipes one through base64.
+echo "==> Signing the extension"
 codesign --force --sign "$IDENTITY" \
   --options runtime \
   --entitlements "$ROOT/quicklook/MDHeroQuickLook.entitlements" \

--- a/src/quicklook/preview.ts
+++ b/src/quicklook/preview.ts
@@ -28,6 +28,21 @@ function initMermaid(isDark: boolean): void {
     // JS/URL bindings from untrusted diagram source. Do not relax this; see
     // CLAUDE.md's security invariants.
     securityLevel: "strict",
+    // #security: render labels as SVG <text>, never as HTML inside
+    // <foreignObject>. DOMPurify >= 3.4 strips HTML from foreignObject (it is
+    // a known XSS vector — the same class the Mermaid disclosure was about),
+    // which would otherwise leave every diagram with empty shapes. Keeping
+    // labels in pure SVG means there is no HTML inside the SVG to sanitize.
+    //
+    // This is here BEFORE the app itself carries it: the fix lives on
+    // `chore/deps-security-refresh-rebased` (5a03430) and touches only
+    // MarkdownRenderer.svelte, which predates this file. Landing it here now
+    // means the DOMPurify 3.4 bump cannot silently empty every diagram in the
+    // Quick Look preview. tests/unit/quicklook-bundle.test.ts enforces that the
+    // preview never falls behind the app on these options again.
+    htmlLabels: false,
+    flowchart: { htmlLabels: false },
+    class: { htmlLabels: false },
     themeVariables: isDark
       ? {
           primaryColor: "#0A1E2E",

--- a/tests/unit/quicklook-bundle.test.ts
+++ b/tests/unit/quicklook-bundle.test.ts
@@ -189,3 +189,49 @@ describe("the generated page's security policy", () => {
     expect(script).toMatch(/__MDHERO_BOOT__/);
   });
 });
+
+/**
+ * Source-level guards for the native shell. These properties are security
+ * relevant, cheap to delete by accident, and covered by nothing else — the
+ * Swift has no test target, and the failures they prevent are all silent.
+ */
+describe("the extension's native shell", () => {
+  const swift = read("quicklook/Preview.swift");
+  const buildScript = read("quicklook/build-appex.sh");
+
+  it("refuses any navigation except the document it loads itself", () => {
+    // No CSP directive stops a link click, and DOMPurify rightly leaves https:
+    // links in the document. Following one would beacon out of a process that
+    // holds com.apple.security.network.client.
+    expect(swift).toMatch(/decidePolicyFor navigationAction/);
+    expect(swift).toMatch(/decisionHandler\(\.cancel\)/);
+    expect(swift).toMatch(/expectingInitialLoad/);
+  });
+
+  it("fails closed if the CSP nonce cannot be generated", () => {
+    // A discarded SecRandomCopyBytes status leaves 16 zero bytes, making the
+    // nonce predictable — which is the only property it has.
+    expect(swift).toMatch(/errSecSuccess/);
+    expect(swift).not.toMatch(/_ = bytes\.withUnsafeMutableBytes/);
+  });
+
+  it("escapes document text so it cannot close the script element", () => {
+    expect(swift).toMatch(/JSONSerialization/);
+    expect(swift).toMatch(/u003C/);
+  });
+
+  it("does not echo the signing identity", () => {
+    // Comment lines are stripped first: the script explains *why* it does not
+    // echo $IDENTITY, and prose about the rule must not trip the rule.
+    const commands = buildScript
+      .split("\n")
+      .filter((line) => !line.trim().startsWith("#"))
+      .join("\n");
+    expect(commands).not.toMatch(/echo[^\n]*\$IDENTITY/);
+  });
+
+  it("stamps the bundle version without a fragile sed expression", () => {
+    expect(buildScript).not.toMatch(/sed[^\n]*__VERSION__/);
+    expect(buildScript).toMatch(/PlistBuddy/);
+  });
+});

--- a/tests/unit/quicklook-bundle.test.ts
+++ b/tests/unit/quicklook-bundle.test.ts
@@ -97,6 +97,57 @@ describe("the Quick Look path reuses the app's renderer", () => {
     expect(preview).toMatch(/securityLevel:\s*"strict"/);
     expect(component).toMatch(/securityLevel:\s*"strict"/);
   });
+
+  /**
+   * The drift guard.
+   *
+   * The failure this prevents is silent and was days away from happening: a
+   * Mermaid hardening option gets added to the app and not to the preview.
+   * `htmlLabels: false` is the live example — DOMPurify >= 3.4 strips HTML out
+   * of <foreignObject>, where Mermaid puts node labels by default, so without
+   * that option every diagram renders as empty shapes. The app's fix
+   * (5a03430, on the dependency branch) touched MarkdownRenderer.svelte alone
+   * because it predates the Quick Look path.
+   *
+   * Nothing would have caught it: no test renders a diagram, so CI stays green
+   * and the first report comes from a user looking at blank boxes.
+   *
+   * The invariant asserted is a superset, not equality: the preview must carry
+   * every Mermaid security option the app carries. It may be ahead — it is
+   * today — but it must never be behind. Renders in Quick Look happen outside
+   * the app's CSP, so "at least as locked down" is the direction that matters.
+   */
+  const mermaidSecurityOptions = (src: string): string[] => {
+    const init = src.slice(src.indexOf("mermaid.initialize"));
+    const body = init.slice(0, init.indexOf("themeVariables"));
+    return [...body.matchAll(/(\w+):\s*(?:"([^"]*)"|(false|true))/g)]
+      .map((m) => `${m[1]}=${m[2] ?? m[3]}`)
+      .filter((opt) => !opt.startsWith("theme=") && !opt.startsWith("startOnLoad="))
+      .sort();
+  };
+
+  it("never lets the preview fall behind the app on Mermaid security options", () => {
+    const app = mermaidSecurityOptions(component);
+    const ql = mermaidSecurityOptions(preview);
+
+    expect(app.length, "parsed no options from MarkdownRenderer.svelte").toBeGreaterThan(0);
+    expect(ql.length, "parsed no options from preview.ts").toBeGreaterThan(0);
+
+    const missing = app.filter((opt) => !ql.includes(opt));
+    expect(
+      missing,
+      `Quick Look is missing Mermaid security options the app has: ${missing.join(", ")}. ` +
+        "Add them to src/quicklook/preview.ts — see CLAUDE.md invariant 1b.",
+    ).toEqual([]);
+  });
+
+  it("keeps Mermaid labels as SVG text in the preview", () => {
+    // Specifically guards the DOMPurify 3.4 interaction; all three spellings
+    // are needed because Mermaid reads them per-diagram-type.
+    expect(preview).toMatch(/htmlLabels:\s*false/);
+    expect(preview).toMatch(/flowchart:\s*\{\s*htmlLabels:\s*false\s*\}/);
+    expect(preview).toMatch(/class:\s*\{\s*htmlLabels:\s*false\s*\}/);
+  });
 });
 
 describe("the generated page's security policy", () => {


### PR DESCRIPTION
Fixes every finding from the retrospective security review of #115: **F1, F2, F3, F4 and the `sed` nit.**

## F1 — HIGH, time-sensitive. The deps branch would have silently emptied every diagram.

`5a03430`, on `chore/deps-security-refresh-rebased`, adds `htmlLabels: false` to `MarkdownRenderer.svelte` — only there, because it was authored on 6 Sep, before the Quick Look path existed. DOMPurify >= 3.4 strips HTML out of `<foreignObject>`, which is exactly where Mermaid puts node labels. The moment that branch merges, the app keeps its labels, the preview renders empty shapes, and **CI stays green** because no test renders a diagram.

Fixed in `preview.ts`, plus the guard that was missing. The guard asserts a **superset, not equality**: the preview must carry every Mermaid security option the app carries, may be ahead (it is today), but must never fall behind. Previews render outside the app's CSP, so "at least as locked down" is the direction that matters.

**This should land before `chore/deps-security-refresh-rebased` or #84.** It won't conflict — that branch touches `MarkdownRenderer.svelte`, this touches `preview.ts`.

## F2 — MEDIUM. No navigation policy.

The CSP stops script, forms and `base-uri`. No CSP directive stops a **link click**, and DOMPurify quite correctly leaves `https:` links in a document. Following one navigates the web view to an attacker-chosen URL from a process holding `com.apple.security.network.client` — turning any previewed file into a beacon: reader's IP, timing, and the fact that the document was opened.

Only the one in-memory document the controller loads may now navigate; everything else is cancelled and logged. Links are dead in the preview — open the file in MDHero to follow them.

## F4 — LOW. Nonce ignored the RNG status.

`makeNonce` discarded the `SecRandomCopyBytes` result. On failure the buffer stays 16 zero bytes and the CSP nonce becomes predictable, destroying the only property it has. It now throws; the caller already propagates.

## F3 — LOW. Echoed signing identity.

`build-appex.sh` no longer echoes `$IDENTITY`. CI masks it, and the identity is recoverable from any shipped binary via `codesign -dv`, so this was never an exposure — echoing secret-sourced values is just the habit that leaks later.

## Nit — fragile `sed`

Version stamping moves from `sed` to `PlistBuddy`, so a `/` in a version string cannot corrupt the expression.

## Verification

Rendering, not just a green suite — CLAUDE.md is explicit that the suite is not evidence for this path. Three diagram types through the real built bundle, inspected in a browser:

```json
{
  "diagramsRendered": 3,
  "leftoverMermaidCodeBlocks": 0,
  "svgTextNodes": 13,
  "foreignObjectCount": 0,
  "sampleLabels": ["Space key", "Finder Node", "appex", "WKWebView", "Alice", "Bob"]
}
```

`foreignObjectCount: 0` is the line that matters: no HTML inside the SVG at all, so the DOMPurify 3.4 bump becomes a non-event.

Runtime check on the navigation policy: the extension renders clean with no blocked-navigation entry, confirming the policy is not cancelling its own document — the regression that would have shipped a blank preview.

**Every guard was confirmed to fail when its fix is reverted.** The F1 guard reports:

```
Quick Look is missing Mermaid security options the app has:
htmlLabels=false, htmlLabels=false, htmlLabels=false.
Add them to src/quicklook/preview.ts — see CLAUDE.md invariant 1b.
```

Gate: **124/124** (baseline 117), svelte-check 0 errors / 9 warnings = baseline.

## Not verified

The click-cancel path itself needs UI automation; I verified the allow path renders and reviewed the cancel branch, but did not simulate a click inside a live Quick Look panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KuoMLLm8mrKwzZsWVbaxRP
